### PR TITLE
Add and use prepare-python action

### DIFF
--- a/.github/actions/prepare-python.yml
+++ b/.github/actions/prepare-python.yml
@@ -1,0 +1,47 @@
+# See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action#creating-an-action-metadata-file
+
+name: "Prepare Python"
+author: "Konrad Kleine"
+description: "Checks out this repos source code and sets up the python environment"
+inputs:
+  checkout-path:
+    description: "Where to checkout the project"
+    required: false
+    default: "llvm-snapshot"
+  checkout-ref:
+    description: "Which branch/tag/ref to checkout"
+    required: false
+    default: "main"
+  fetch-depth:
+    description: "Number of commits to fetch. 0 indicates all history for all branches and tags. Default 1."
+    required: false
+    default: 1
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup python"
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+
+    - name: "Checkout this project into ${{ inputs.checkout-path }}"
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ inputs.checkout-ref }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 1
+        path: ${{ inputs.checkout-path }}
+
+    - name: "Check for cached dependencies"
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: ""
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ inputs.checkout-path }}/requirements.txt

--- a/.github/workflows/generate-snapshot-tarballs.yml
+++ b/.github/workflows/generate-snapshot-tarballs.yml
@@ -55,34 +55,28 @@ jobs:
   # the old ones from today; otherwise there would be a conflict. As a measure
   # of not storing old snapshots for too long we'll delete older ones here as
   # well.
+  delete-old-tarballs-and-todays:
+    name: delete old tarballs and todays
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/prepare-python.yml
+
+      - name: "delete assets older than 33 days and from today"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          llvm-snapshots/github/delete-assets.py \
+            --token ${{ secrets.GITHUB_TOKEN }} \
+            --project ${{ github.repository }} \
+            --release-name source-snapshot \
+            --delete-older 33 \
+            --delete-today
+
   source-tarballs:
     name: generate snapshot tarballs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: "checkout this project"
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 1
-          path: llvm-snapshots
-
-      - name: "Check for cached dependencies"
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - run: |
-          python -m pip install --upgrade pip
-          pip install -r llvm-snapshots/requirements.txt
+      - uses: ./.github/actions/prepare-python.yml
 
       - name: "checkout llvm/llvm-project"
         uses: actions/checkout@v4
@@ -115,17 +109,6 @@ jobs:
           llvm-project/llvm/utils/release/export.sh \
             --git-ref ${{ env.sha }} \
             --template '${PROJECT}-${YYYYMMDD}.src.tar.xz'
-
-      - name: "delete assets older than 33 days and from today"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          llvm-snapshots/github/delete-assets.py \
-            --token ${{ secrets.GITHUB_TOKEN }} \
-            --project ${{ github.repository }} \
-            --release-name source-snapshot \
-            --delete-older 33 \
-            --delete-today
 
       - name: >-
           upload source-snapshots and version files to the 'source-snapshot'

--- a/.github/workflows/update-build-time-diagrams.yml
+++ b/.github/workflows/update-build-time-diagrams.yml
@@ -32,34 +32,15 @@ jobs:
           mkdir -p ~/.config
           printf "$COPR_CONFIG_FILE" > ~/.config/copr
 
-      - uses: actions/setup-python@v5
+      - uses: ./.github/actions/prepare-python.yml
         with:
-          python-version: '3.10'
-
-      - name: Checkout main branch
-        uses: actions/checkout@v4
-        with:
-          ref: 'main'
-          path: 'main'
+          checkout-path: main
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
           ref: 'gh-pages'
           path: 'gh-pages'
-
-      - name: "Check for cached dependencies"
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r main/build-stats/requirements.txt
 
       - name: Setup git config
         run: |


### PR DESCRIPTION
This action checks out the repository and configures the python environment and makes use of a cache. This way we can avoid code duplication and split our workflows into more than one job more easily. See the portion that deletes the old snapshots for example. That is done in parallel to generating the new snapshots now.
