### PR TITLE
Automated testing

### DIFF
--- a/.github/workflows/check-todays-snapshot.yml
+++ b/.github/workflows/check-todays-snapshot.yml
@@ -63,6 +63,8 @@ jobs:
         shell: bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TESTING_FARM_API_TOKEN_PUBLIC_RANCH: ${{ secrets.TESTING_FARM_API_TOKEN_PUBLIC_RANCH }}
+          TESTING_FARM_API_TOKEN_REDHAT_RANCH: ${{ secrets.TESTING_FARM_API_TOKEN_REDHAT_RANCH }}
         run: |
           extra_args=""
 

--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -6,12 +6,7 @@ import dataclasses
 import enum
 import logging
 import pathlib
-import re
-import os
 
-import regex
-
-import snapshot_manager.build_status as build_status
 import snapshot_manager.util as util
 
 
@@ -346,8 +341,8 @@ def get_cause_from_build_log(
     # TODO: Feel free to add your check here...
 
     logging.info(" Default to unknown cause...")
-    _, tail, _ = util._run_cmd(cmd=f"tail {build_log_file}")
-    _, rpm_build_errors, _ = util._run_cmd(
+    _, tail, _ = util.run_cmd(cmd=f"tail {build_log_file}")
+    _, rpm_build_errors, _ = util.run_cmd(
         cmd=rf"sed -n -e '/RPM build errors/,/Finish:/' p {build_log_file}"
     )
     _, errors_to_look_into, _ = util.grep_file(

--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -141,55 +141,11 @@ class BuildState:
 
     @property
     def os(self):
-        """Get the os part of a chroot string
-
-        Args:
-            chroot (str): A string like "fedora-rawhide-x86_64
-
-        Returns:
-            str: The OS part of the chroot string.
-
-        Examples:
-
-        >>> BuildState(chroot="fedora-rawhide-x86_64").os
-        'fedora-rawhide'
-
-        >>> BuildState(chroot="fedora-40-ppc64le").os
-        'fedora-40'
-
-        >>> BuildState(chroot="fedora-rawhide-NEWARCH").os
-        'fedora-rawhide'
-        """
-        match = re.search(pattern=r"[^-]+-[0-9,rawhide]+", string=self.chroot)
-        if match:
-            return str(match[0])
-        return ""
+        return util.chroot_os(self.chroot)
 
     @property
     def arch(self):
-        """Get architecture part of a chroot string
-
-        Args:
-            chroot (str): A string like "fedora-rawhide-x86_64
-
-        Returns:
-            str: The architecture part of the chroot string.
-
-        Example:
-
-        >>> BuildState(chroot="fedora-rawhide-x86_64").arch
-        'x86_64'
-
-        >>> BuildState(chroot="fedora-40-ppc64le").arch
-        'ppc64le'
-
-        >>> BuildState(chroot="fedora-rawhide-NEWARCH").arch
-        'NEWARCH'
-        """
-        match = regex.search(pattern=r"[^-]+-[^-]+-\K[^\s]+", string=self.chroot)
-        if match:
-            return str(match[0])
-        return ""
+        return util.chroot_arch(self.chroot)
 
     @property
     def source_build_url(self) -> str:

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -56,6 +56,9 @@ class Config:
     )
     """URL to the Copr monitor page. We'll use this in the issue comment's body, not for querying Copr."""
 
+    test_repo_url: str = "https://github.com/fedora-llvm-team/llvm-snapshots"
+    """TBD"""
+
     @property
     def copr_projectname(self) -> str:
         """Takes the copr_project_tpl and replaces the YYYYMMDD placeholder (if any) with a date.
@@ -70,6 +73,11 @@ class Config:
         'begin-NODATE-end'
         """
         return self.copr_project_tpl.replace("YYYYMMDD", self.yyyymmdd)
+
+    @property
+    def copr_project(self) -> str:
+        """Returns the owner/project string for the current date."""
+        return f"{self.config.copr_ownername}/{self.config.copr_projectname}"
 
     @property
     def copr_monitor_url(self) -> str:

--- a/snapshot_manager/snapshot_manager/copr_util.py
+++ b/snapshot_manager/snapshot_manager/copr_util.py
@@ -1,5 +1,5 @@
 """
-copr
+copr_util
 """
 
 import logging

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -176,3 +176,18 @@ remove the aforementioned labels.
 
     def create_labels_for_archs(self, labels: list[str], **kw_args):
         self._create_labels(labels=labels, prefix="arch/", color="C5DEF5", *kw_args)
+
+    def create_labels_for_in_testing(self, labels: list[str], **kw_args):
+        self._create_labels(
+            labels=labels, prefix="in_testing/", color="C2E0C6", *kw_args
+        )
+
+    def create_labels_for_tested_on(self, labels: list[str], **kw_args):
+        self._create_labels(
+            labels=labels, prefix="tested_on/", color="0E8A16", *kw_args
+        )
+
+    def create_labels_for_failed_on(self, labels: list[str], **kw_args):
+        self._create_labels(
+            labels=labels, prefix="failed_on/", color="D93F0B", *kw_args
+        )

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -1,5 +1,5 @@
 """
-github
+github_util
 """
 
 import datetime

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -273,7 +273,6 @@ class SnapshotManager:
             --context distro={util.chroot_os(chroot)} \
             --context arch=${util.chroot_arch(chroot)} \
             --no-wait \
-            --dry-run \
             --context snapshot={self.config.yyyymmdd}"""
         exit_code, stdout, stderr = util.run_cmd(cmd, timeout_secs=None)
         if exit_code == 0:

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -5,12 +5,16 @@ SnapshotManager
 import datetime
 import logging
 import os
+import re
+
+import github.Issue
 
 import snapshot_manager.build_status as build_status
 import snapshot_manager.copr_util as copr_util
 import snapshot_manager.github_util as github_util
 import snapshot_manager.config as config
 import snapshot_manager.util as util
+import snapshot_manager.testing_farm_util as tf
 
 
 class SnapshotManager:
@@ -42,6 +46,11 @@ class SnapshotManager:
         states = [state.augment_with_error() for state in states]
 
         comment_body = issue.body
+
+        logging.info(
+            "Extract and sanitize testing-farm information out of the last comment body."
+        )
+        testing_farm_requests = tf.parse_comment_for_request_ids(comment_body)
 
         logging.info(
             "Shorten the issue body comment to the update marker so that we can append to it"
@@ -80,7 +89,7 @@ class SnapshotManager:
         arch_labels = list({f"arch/{err.arch}" for err in errors})
         strategy_labels = [f"strategy/{self.config.build_strategy}"]
         other_labels: list[str] = []
-        if errors is None or len(errors) > 0:
+        if errors is None and len(errors) > 0:
             other_labels.append("broken_snapshot_detected")
 
         logging.info("Create labels")
@@ -125,13 +134,6 @@ class SnapshotManager:
             logging.info(f"Adding label: {label}")
             issue.add_to_labels(label)
 
-        # TODO(kwk): Once only tested_on/<CHROOT> labels are assigned to the
-        # issue we can turn this to True.
-        num_builds_to_succeed = len(
-            all_chroots
-        )  # The wording is misleading this is the number of chroots that need successful builds
-        num_tests_to_run = len(all_chroots)
-        all_tests_succeeded = True
         labels_on_issue = [label.name for label in issue.labels]
 
         for chroot in all_chroots:
@@ -145,70 +147,137 @@ class SnapshotManager:
             )
 
             if not builds_succeeded:
-                all_tests_succeeded = False
                 continue
 
-            num_builds_to_succeed -= 1
-
             logging.info(f"All builds in chroot {chroot} have succeeded!")
+
             if f"in_testing/{chroot}" in labels_on_issue:
                 logging.info(
                     f"Chroot {chroot} is currently in testing! Not kicking off new tests."
                 )
-                all_tests_succeeded = False
+                if chroot in testing_farm_requests:
+                    request_id = testing_farm_requests[chroot]
+                    watch_result, artifacts_url = self.watch_testing_farm_request(
+                        request_id=request_id
+                    )
+                    if watch_result in [
+                        tf.TestingFarmWatchResult.TESTS_ERROR,
+                        tf.TestingFarmWatchResult.TESTS_FAILED,
+                    ]:
+                        issue.remove_from_labels(f"in_testing/{chroot}")
+                        issue.add_to_labels(f"failed_on/{chroot}")
+                    elif watch_result == tf.TestingFarmWatchResult.TESTS_PASSED:
+                        issue.remove_from_labels(f"in_testing/{chroot}")
+                        issue.add_to_labels(f"tested_on/{chroot}")
+
             elif f"tested_on/{chroot}" in labels_on_issue:
                 logging.info(
                     f"Chroot {chroot} has passed tests testing! Not kicking off new tests."
                 )
-                num_tests_to_run -= 1
             elif f"failed_on/{chroot}" in labels_on_issue:
                 logging.info(
                     f"Chroot {chroot} has unsuccessful tests! Not kicking off new tests."
                 )
-                num_tests_to_run -= 1
-                all_tests_succeeded = False
             else:
-                logging.info(f"Kicking off new tests for chroot {chroot}.")
-                all_tests_succeeded = False
+                logging.info(f"chroot {chroot} has no tests associated yet.")
+                request_id = self.make_testing_farm_request(chroot=chroot)
+                testing_farm_requests[chroot] = request_id
                 issue.add_to_labels(f"in_testing/{chroot}")
-                # TODO(kwk): Add testing-farm code here, something like this:
-                # TODO(kwk): Decide how if we want to wait for test results (probably not) and if not how we can check for the results later.
-                ranch = util.pick_testing_farm_ranch(chroot)
-                logging.info(f"Using testing-farm ranch: {ranch}")
-                if ranch == "public":
-                    os.environ["TESTING_FARM_API_TOKEN"] = os.getenv(
-                        "TESTING_FARM_API_TOKEN_PUBLIC_RANCH"
-                    )
-                if ranch == "redhat":
-                    os.environ["TESTING_FARM_API_TOKEN"] = os.getenv(
-                        "TESTING_FARM_API_TOKEN_REDHAT_RANCH"
-                    )
-                cmd = f"""testing-farm \
-                    request \
-                    --compose {util.chroot_os(chroot).upper()} \
-                    --git-url {self.config.test_repo_url} \
-                    --arch {util.chroot_arch(chroot)} \
-                    --plan /tests/snapshot-gating \
-                    --environment COPR_PROJECT={self.config.copr_project} \
-                    --context distro={util.chroot_os(chroot)} \
-                    --context arch=${util.chroot_arch(chroot)} \
-                    --user-webpage{issue.html_url} \
-                    --no-wait \
-                    --dry-run \
-                    --context snapshot={self.config.yyyymmdd}"""
-                exit_code, stdout, stderr = util._run_cmd(cmd, timeout_secs=None)
-                # if exit_code == 0:
+
+        logging.info("Appending testing farm requests to the comment body.")
+        comment_body += "\n\n" + tf.chroot_request_ids_to_html_comment(
+            testing_farm_requests
+        )
+        issue.edit(body=comment_body)
 
         logging.info("Checking if issue can be closed")
-        building_is_done = num_builds_to_succeed == 0
-        testing_is_done = num_tests_to_run == 0 and all_tests_succeeded
-
-        if building_is_done and testing_is_done:
-            msg = f"@{self.config.maintainer_handle}, all required packages have been successfully built in all required chroots. We'll close this issue for you now as completed. Congratulations!"
+        issue.update()
+        tested_chroot_labels = [
+            label.name for label in issue.labels if label.name.startswith("tested_on/")
+        ]
+        required_chroot_abels = ["tested_on/{chroot}" for chroot in all_chroots]
+        if set(tested_chroot_labels) == set(required_chroot_abels):
+            msg = f"@{self.config.maintainer_handle}, all required packages have been successfully built and tested on all required chroots. We'll close this issue for you now as completed. Congratulations!"
             logging.info(msg)
             issue.create_comment(body=msg)
             issue.edit(state="closed", state_reason="completed")
+            # TODO(kwk): Promotion of issue goes here.
         else:
             logging.info("Cannot close issue yet.")
 
         logging.info(f"Updated today's issue: {issue.html_url}")
+
+    def watch_testing_farm_request(
+        self, request_id: str
+    ) -> tuple[util.TestingFarmWatchResult, str]:
+        request_id = tf.sanitize_request_id(request_id=request_id)
+        cmd = f"testing-farm watch --no-wait --id {request_id}"
+        exit_code, stdout, stderr = util.run_cmd(cmd=cmd)
+        if exit_code != 0:
+            raise SystemError(
+                f"failed to watch 'testing-farm request': {cmd}\n\nstdout: {stdout}\n\nstderr: {stderr}"
+            )
+
+        watch_result, artifacts_url = tf.parse_for_watch_result(stdout)
+        if watch_result is None:
+            raise SystemError(
+                f"failed to watch 'testing-farm request': {cmd}\n\nstdout: {stdout}\n\nstderr: {stderr}"
+            )
+        return (watch_result, artifacts_url)
+
+    def make_testing_farm_request(self, chroot: str) -> str:
+        """Runs a "testing-farm request" command and returns the request ID.
+
+        The request is made without waiting for the result.
+        It is the responsibility of the caller of this function to run "testing-farm watch --id <REQUEST_ID>",
+        where "<REQUEST_ID>" is the result of this function.
+
+        Depending on the chroot, we'll automatically select the proper testing-farm ranch for you.
+        For this to work you'll have to set the
+        TESTING_FARM_API_TOKEN_PUBLIC_RANCH and
+        TESTING_FARM_API_TOKEN_REDHAT_RANCH
+        environment variables. We'll then use one of them to set the TESTING_FARM_API_TOKEN
+        environment variable for the actual call to testing-farm.
+
+        Args:
+            chroot (str): The chroot that you want to run tests for.
+
+        Raises:
+            SystemError: When the testing-farm request failed
+
+        Returns:
+            str: Request ID
+        """
+        logging.info(f"Kicking off new tests for chroot {chroot}.")
+        all_tests_succeeded = False
+
+        # TODO(kwk): Add testing-farm code here, something like this:
+        # TODO(kwk): Decide how if we want to wait for test results (probably not) and if not how we can check for the results later.
+        ranch = tf.select_ranch(chroot)
+        logging.info(f"Using testing-farm ranch: {ranch}")
+        if ranch == "public":
+            os.environ["TESTING_FARM_API_TOKEN"] = os.getenv(
+                "TESTING_FARM_API_TOKEN_PUBLIC_RANCH"
+            )
+        if ranch == "redhat":
+            os.environ["TESTING_FARM_API_TOKEN"] = os.getenv(
+                "TESTING_FARM_API_TOKEN_REDHAT_RANCH"
+            )
+        cmd = f"""testing-farm \
+            request \
+            --compose {util.chroot_os(chroot).capitalize()} \
+            --git-url {self.config.test_repo_url} \
+            --arch {util.chroot_arch(chroot)} \
+            --plan /tests/snapshot-gating \
+            --environment COPR_PROJECT={self.config.copr_projectname} \
+            --context distro={util.chroot_os(chroot)} \
+            --context arch=${util.chroot_arch(chroot)} \
+            --no-wait \
+            --dry-run \
+            --context snapshot={self.config.yyyymmdd}"""
+        exit_code, stdout, stderr = util.run_cmd(cmd, timeout_secs=None)
+        if exit_code == 0:
+            return tf.parse_output_for_request_id(stdout)
+        raise SystemError(
+            f"failed to run 'testing-farm request': {cmd}\n\nstdout: {stdout}\n\nstderr: {stderr}"
+        )

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -209,7 +209,7 @@ class SnapshotManager:
 
     def watch_testing_farm_request(
         self, request_id: str
-    ) -> tuple[util.TestingFarmWatchResult, str]:
+    ) -> tuple[tf.TestingFarmWatchResult, str]:
         request_id = tf.sanitize_request_id(request_id=request_id)
         cmd = f"testing-farm watch --no-wait --id {request_id}"
         exit_code, stdout, stderr = util.run_cmd(cmd=cmd)

--- a/snapshot_manager/snapshot_manager/testing_farm_util.py
+++ b/snapshot_manager/snapshot_manager/testing_farm_util.py
@@ -1,0 +1,263 @@
+"""
+testing_farm_util
+"""
+
+import enum
+import logging
+import re
+import string
+import uuid
+
+import regex
+
+import snapshot_manager.util as util
+
+
+@enum.unique
+class TestingFarmWatchResult(enum.StrEnum):
+    """An enum to represent states from a testing-farm watch call
+
+    See https://gitlab.com/testing-farm/cli/-/blob/main/src/tft/cli/commands.py?ref_type=heads#L248-272
+    """
+
+    REQUEST_WAITING_TO_BE_QUEUED = "request is waiting to be queued"  #  Package sources are being imported into Copr DistGit.
+    REQUEST_QUEUED = (
+        "request is queued"  # Build is waiting in queue for a backend worker.
+    )
+    REQUEST_RUNNING = (
+        "request is running"  # Backend worker is trying to acquire a builder machine.
+    )
+    TESTS_PASSED = "tests passed"  # Build in progress.
+    TESTS_FAILED = "tests failed"  # Successfully built.
+    TESTS_ERROR = "tests error"  # Build has been forked from another build.
+    TESTS_UNKNOWN = "tests unknown"  # This package was skipped, see the reason for each chroot separately.
+
+    @classmethod
+    def all_watch_results(cls) -> list["TestingFarmWatchResult"]:
+        return [s for s in TestingFarmWatchResult]
+
+    @property
+    def is_complete(self) -> bool:
+        """Returns True if the watch result indicates that the testing-farm
+        request has been completed. The outcome doesn't matter.
+        """
+        if self.value in [
+            self.REQUEST_WAITING_TO_BE_QUEUED,
+            self.REQUEST_QUEUED,
+            self.REQUEST_RUNNING,
+        ]:
+            return False
+        return True
+
+    @property
+    def expect_artifacts_url(self) -> bool:
+        """Returns True if for the watch result we can expect and artifacts URL in the watch output."""
+        if self.value in [self.REQUEST_WAITING_TO_BE_QUEUED, self.REQUEST_QUEUED]:
+            return False
+        return True
+
+    def is_watch_result(self, string: str) -> bool:
+        return string in self.all_watch_results()
+
+
+def select_ranch(chroot: str) -> str:
+    """Depending on the chroot, we decide if we build in the public or redhat testing ranch
+
+    Args:
+        chroot (str): chroot to use for determination of ranch
+
+    Returns:
+        str: "public", "private" or None
+
+    Examples:
+
+    >>> select_ranch("fedora-rawhide-x86_64")
+    'public'
+
+    >>> select_ranch("fedora-40-aarch64")
+    'public'
+
+    >>> select_ranch("rhel-9-x86_64")
+    'redhat'
+
+    >>> select_ranch("fedora-rawhide-s390x")
+    'redhat'
+
+    >>> select_ranch("fedora-rawhide-ppc64le")
+    'redhat'
+
+    >>> select_ranch("fedora-rawhide-i386")
+    'redhat'
+    """
+    util.expect_chroot(chroot)
+    ranch = None
+    if re.search(r"(x86_64|aarch64)$", chroot):
+        ranch = "public"
+    if re.search(r"(^rhel|(ppc64le|s390x|i386)$)", chroot):
+        ranch = "redhat"
+    return ranch
+
+
+def parse_comment_for_request_ids(comment_body: str) -> dict:
+    """Extracts and sanitizes testing_farm requests from a github comment and returns a
+    dictionary with chroots as keys and testing-farm request IDs as values.
+
+    If a chroot doesn't have the chroot format it won't be in the dictionary.
+    If a request ID doesn't have the proper format, the chroot won't be added to the dictionary.
+    If the comment body contains more than one entry for a the same chroot, the last one will be taken.
+
+    Args:
+        comment_body (str): A github comment body that contains invisible (HTML) comments.
+
+    Returns:
+        dict: A dictionary with chroots as keys and testing-farm request IDs as values
+
+    Example:
+
+    >>> comment_body='''
+    ... Bla bla <!--TESTING_FARM:fedora-rawhide-x86_64/271a79e8-fc9a-4e1d-95fe-567cc9d62ad4--> bla bla
+    ... Foo bar. <!--TESTING_FARM:fedora-39-x86_64/11111111-fc9a-4e1d-95fe-567cc9d62ad4--> fjjd
+    ... Foo BAR. <!--TESTING_FARM:fedora-39-x86_64/22222222-fc9a-4e1d-95fe-567cc9d62ad4--> fafa
+    ... Foo bAr. <!--TESTING_FARM:invalid-chroot/33333333-fc9a-4e1d-95fe-567cc9d62ad4--> fafa
+    ... FOO bar. <!--TESTING_FARM: fedora-40-x86_64/; cat /tmp/secret/file--> fafa
+    ... FOO bar. <!--TESTING_FARM: fedora-40-x86_64/33333333-fc9a-4e1d-95fe-567cc9d62ad4--> fafa
+    ... '''
+    >>> parse_comment_for_request_ids(comment_body=comment_body)
+    {'fedora-rawhide-x86_64': '271a79e8-fc9a-4e1d-95fe-567cc9d62ad4', 'fedora-39-x86_64': '22222222-fc9a-4e1d-95fe-567cc9d62ad4', 'fedora-40-x86_64': '33333333-fc9a-4e1d-95fe-567cc9d62ad4'}
+    """
+    testing_farm_requests = dict()
+    for ci in [
+        comb.split("/")
+        for comb in re.findall(r"<!--TESTING_FARM:(.*?)-->", comment_body)
+    ]:
+        try:
+            chroot = util.expect_chroot(ci[0]).strip()
+            request_id = sanitize_request_id(ci[1]).strip()
+        except ValueError as e:
+            logging.info(f"ignoring: {ci[0]} and {ci[1]} {str(e)}")
+        else:
+            testing_farm_requests[chroot] = request_id
+    return testing_farm_requests
+
+
+def sanitize_request_id(request_id: str) -> str:
+    """Sanitizes a testing-farm request ID by ensuring that it matches a pattern.
+
+    Args:
+        request_id (str): A testing-farm request ID
+
+    Raises:
+        ValueError: if the given string is not in the right format
+
+    Returns:
+        str: the string that matched the pattern
+
+    Examples:
+
+    >>> sanitize_request_id(request_id="271a79e8-fc9a-4e1d-95fe-567cc9d62ad4")
+    '271a79e8-fc9a-4e1d-95fe-567cc9d62ad4'
+
+    >>> sanitize_request_id(request_id="; cat /etc/passwd")
+    Traceback (most recent call last):
+     ...
+    ValueError: string is not a valid testing-farm request ID: badly formed hexadecimal UUID string
+    """
+    try:
+        res = uuid.UUID(request_id)
+    except Exception as e:
+        raise ValueError(f"string is not a valid testing-farm request ID: {e}")
+    return request_id
+
+
+def clean_testing_farm_output(mystring: str) -> str:
+    """Returns a string with only printable characters.
+
+    Args:
+        mystring (str): The output of a testing-farm CLI command
+
+    Returns:
+        str: The same as the input but without anything that's not printable.
+    """
+    return "".join(filter(lambda x: x in string.printable, mystring))
+
+
+def parse_output_for_request_id(string: str) -> str:
+    """Takes in the stdout from a "testing-farm request" command and returns
+    the request ID to be used for watching the request.
+
+    Args:
+        string (str): A "testing-farm request" output.
+
+    Raises:
+        ValueError: If string is not a "testing-farm request" output with the
+        proper line in it, an exception is raised
+
+    Example:
+
+    >>> s='''8J+TpiByZXBvc2l0b3J5IGh0dHBzOi8vZ2l0aHViLmNvbS9mZWRvcmEtbGx2bS10ZWFtL2xsdm0t
+    ... c25hcHNob3RzIHJlZiBtYWluIHRlc3QtdHlwZSBmbWYK8J+SuyBGZWRvcmEtMzkgb24geDg2XzY0
+    ... IArwn5SOIGFwaSBodHRwczovL2FwaS5kZXYudGVzdGluZy1mYXJtLmlvL3YwLjEvcmVxdWVzdHMv
+    ... MjcxYTc5ZTgtZmM5YS00ZTFkLTk1ZmUtNTY3Y2M5ZDYyYWQ0CvCfkbYgcmVxdWVzdCBpcyB3YWl0
+    ... aW5nIHRvIGJlIHF1ZXVlZAo='''
+    >>> import base64
+    >>> s = base64.b64decode(s).decode()
+    >>> parse_output_for_request_id(s)
+    '271a79e8-fc9a-4e1d-95fe-567cc9d62ad4'
+    """
+    string = clean_testing_farm_output(string)
+    match = regex.search(pattern=r"api https:.*/requests/\K.*", string=string)
+    if not match:
+        raise ValueError(
+            f"string doesn't look not a 'testing-farm request' output: {string}"
+        )
+    return str(match[0])
+
+
+def parse_for_watch_result(string: str) -> tuple[TestingFarmWatchResult, str]:
+    """Inspects the output of a testing-farm watch call and returns a tuple of result and artifacts url (if any).
+
+    Args:
+        string (str): The output of a testing-farm watch call.
+
+    Returns:
+        tuple[str, TestingFarmWatchResult]: _description_
+
+    Example:
+    >>> s='''8J+UjiBhcGkgaHR0cHM6Ly9hcGkuZGV2LnRlc3RpbmctZmFybS5pby92MC4xL3JlcXVlc3RzLzI3
+    ... MWE3OWU4LWZjOWEtNGUxZC05NWZlLTU2N2NjOWQ2MmFkNArwn5qiIGFydGlmYWN0cyBodHRwOi8v
+    ... YXJ0aWZhY3RzLm9zY2kucmVkaGF0LmNvbS90ZXN0aW5nLWZhcm0vMjcxYTc5ZTgtZmM5YS00ZTFk
+    ... LTk1ZmUtNTY3Y2M5ZDYyYWQ0CuKdjCB0ZXN0cyBlcnJvcgpOb25lCg=='''
+    >>> import base64
+    >>> s = base64.b64decode(s).decode()
+    >>> get_testing_farm_watch_result(s)
+    (<TestingFarmWatchResult.TESTS_ERROR: 'tests error'>, 'http://artifacts.osci.redhat.com/testing-farm/271a79e8-fc9a-4e1d-95fe-567cc9d62ad4')
+    """
+    string = clean_testing_farm_output(string)
+    for watch_result in TestingFarmWatchResult.all_watch_results():
+        if not re.search(pattern=str(watch_result), string=string):
+            continue
+        if not watch_result.expect_artifacts_url:
+            return (watch_result, None)
+        url_match = re.search(pattern=r"artifacts http[s]?://.*", string=string)
+        if not url_match:
+            raise ValueError(f"expected an artifacts URL but couldn't find one")
+        artifacts_url = str(
+            re.search(pattern=r"http[s]?://.*", string=url_match[0])[0]
+        ).strip()
+        return (watch_result, artifacts_url)
+
+    return (None, None)
+
+
+def chroot_request_ids_to_html_comment(data: dict) -> str:
+    """Converts the data dictionary of chroot -> request ID pairs to html comments.
+
+    Example:
+
+    >>> chroot_request_ids_to_html_comment({"foo": "bar"})
+    '<!--TESTING_FARM:foo/bar-->'
+    """
+    res: list[str] = []
+    for key in data.keys():
+        res.append(f"<!--TESTING_FARM:{key}/{data[key]}-->")
+    return "".join(res)

--- a/snapshot_manager/snapshot_manager/testing_farm_util.py
+++ b/snapshot_manager/snapshot_manager/testing_farm_util.py
@@ -229,7 +229,7 @@ def parse_for_watch_result(string: str) -> tuple[TestingFarmWatchResult, str]:
     ... LTk1ZmUtNTY3Y2M5ZDYyYWQ0CuKdjCB0ZXN0cyBlcnJvcgpOb25lCg=='''
     >>> import base64
     >>> s = base64.b64decode(s).decode()
-    >>> get_testing_farm_watch_result(s)
+    >>> parse_for_watch_result(s)
     (<TestingFarmWatchResult.TESTS_ERROR: 'tests error'>, 'http://artifacts.osci.redhat.com/testing-farm/271a79e8-fc9a-4e1d-95fe-567cc9d62ad4')
     """
     string = clean_testing_farm_output(string)


### PR DESCRIPTION
This is an early attempt to solve what we've discussed in the chat.

1. Once we find a chroot that has all succeeded builds we should run the tests on testing-farm for that chroot. Before starting the tests we should add the label `in_testing/fedora-rawhide-x86_64` (could be any other chroot) to the issue. The CI job runs on a schedule and this signals the next run that even though a chroot only contains succeeded builds, we should not trigger tests but keep calm instead.
2. Once the testing farm results are in, we remove the `in_testing/fedora-rawhide-x86_64` label and add `tested_on/fedora-rawhide-x86_64` or `failed_on/fedora-rawhide-x86_64` to the issue. This will also be interpreted by the CI to not kick of any more tests.
3. Once we have only `tested_on/fedora-rawhide-x86_64` respectively for all chroots, we can consider this build tested and worth promoting.

# TODOs

- [x] Create `in_testing/<chroot>` labels
- [x] Create `tested_on/<chroot>` labels
- [x] Create `failed_on/<chroot>` labels
- [x] Don't start testing if in progress, or already tested (result is irrelevant)
- [x] Kick off testing on testing-farm
- [ ] Kick off promotion