### PR TITLE
Ignore not available testing-farm-tag-repository

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -17,7 +17,7 @@ prepare:
   - how: shell
     script: |
       dnf install -y dnf-plugins-core
-      dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999"
+      dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || true
 adjust:
   - discover+:
       - name: redhat-rpm-config-tests


### PR DESCRIPTION
We don't need the testing-farm-tag-repository which is why we lower its priority. If it doesn't exist, we might as well ignore it.

Fixes #401