### PR TITLE
Add i.e. release/19.0.0 label to daily snapshot issues

### DIFF
--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -69,6 +69,8 @@ class Config:
     label_prefix_tested_on: str = "tested_on/"
     label_prefix_failed_on: str = "failed_on/"
 
+    label_prefix_llvm_release: str = "release/"
+
     @property
     def copr_projectname(self) -> str:
         """Takes the copr_project_tpl and replaces the YYYYMMDD placeholder (if any) with a date.

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -310,6 +310,16 @@ remove the aforementioned labels.
             *kw_args,
         )
 
+    def create_labels_for_llvm_releases(
+        self, labels: list[str], **kw_args
+    ) -> list[github.Label.Label]:
+        return self.create_labels(
+            labels=labels,
+            prefix=self.config.label_prefix_llvm_release,
+            color="2F3950",
+            *kw_args,
+        )
+
     def get_comment(
         self, issue: github.Issue.Issue, marker: str
     ) -> github.IssueComment.IssueComment:

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -425,7 +425,8 @@ class SnapshotManager:
         os_labels = list({f"os/{err.os}" for err in errors})
         arch_labels = list({f"arch/{err.arch}" for err in errors})
         strategy_labels = [f"strategy/{self.config.build_strategy}"]
-        other_labels: list[str] = []
+        llvm_release = util.get_release_for_yyyymmdd(self.config.yyyymmdd)
+        other_labels: list[str] = [llvm_release]
         if errors is None and len(errors) > 0:
             other_labels.append("broken_snapshot_detected")
 
@@ -441,6 +442,7 @@ class SnapshotManager:
         self.github.create_labels_for_in_testing(all_chroots)
         self.github.create_labels_for_tested_on(all_chroots)
         self.github.create_labels_for_failed_on(all_chroots)
+        self.github.create_labels_for_llvm_releases([llvm_release])
 
         # Remove old labels from issue if they no longer apply. This is great
         # for restarted builds for example to make all builds green and be able

--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -171,17 +171,17 @@ def golden_file_path(basename: str, extension: str = ".golden.txt") -> pathlib.P
 
 def get_yyyymmdd_from_string(string: str) -> str:
     """Returns the year-month-day combination in YYYYMMDD form from
-    an issue `title` or raises an error.
+    `string` or raises an error.
 
     Args:
-        title (str): The title of a github issue
+        string (str): e.g. the title of a github issue
 
     Raises:
-        ValueError: If `title` doesn't contain proper YYYYMMDD string
+        ValueError: If `string` doesn't contain proper YYYYMMDD string
         ValueError: If the date in the title is invalid
 
     Returns:
-        str: The year-month-day extracted from `title`
+        str: The year-month-day extracted from `string`
 
     Examples:
 

--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -9,6 +9,7 @@ import subprocess
 import os
 import re
 import datetime
+import functools
 
 import requests
 import regex
@@ -371,6 +372,7 @@ def chroot_arch(chroot: str) -> str:
     return str(match[0])
 
 
+@functools.cache
 def get_git_revision_for_yyyymmdd(yyyymmdd: str) -> str:
     """Get LLVM commit hash for the given date"""
     yyyymmdd = get_yyyymmdd_from_string(yyyymmdd)
@@ -380,6 +382,7 @@ def get_git_revision_for_yyyymmdd(yyyymmdd: str) -> str:
     return response.text.strip()
 
 
+@functools.cache
 def get_release_for_yyyymmdd(yyyymmdd: str) -> str:
     """Get LLVM release (e.g. 19.0.0) for the given date"""
     yyyymmdd = get_yyyymmdd_from_string(yyyymmdd)


### PR DESCRIPTION
- **Cache get_git_revision_for_yyyymmdd and get_release_for_yyyymmdd**
- **Add i.e. release/19.0.0 label to daily snapshot issues**

Fixes #443
