### PR TITLE
Add a pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/prepare-python
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This runs all the checks we run locally for pre-commit but on github. Thereby we also run tmt linting.

Fixes #77

Here are the checks that were run when this PR was created:

![grafik](https://github.com/fedora-llvm-team/llvm-snapshots/assets/193408/97904ef2-8f4f-4d1f-9ba0-c0f781bd0512)
