### PR TITLE
Fix 513

### DIFF
--- a/snapshot_manager/snapshot_manager/testing_farm_util.py
+++ b/snapshot_manager/snapshot_manager/testing_farm_util.py
@@ -597,6 +597,13 @@ class TestingFarmWatchResult(enum.StrEnum):
         >>> s = base64.b64decode(s).decode()
         >>> TestingFarmWatchResult.from_output(s)
         (<TestingFarmWatchResult.PIPELINE_ERROR: 'pipeline error'>, None)
+        >>> s='''8J+UjiBhcGkgaHR0cHM6Ly9hcGkuZGV2LnRlc3RpbmctZmFybS5pby92MC4xL3JlcXVlc3RzLzk3
+        ... YTdjYzI0LTY5MjYtNDA1OS04NGFjLWQwMDc4Mjk3YzMxOQrwn5qAIHJlcXVlc3QgaXMgcnVubmlu
+        ... Zwrwn5qiIGFydGlmYWN0cyBodHRwczovL2FydGlmYWN0cy5kZXYudGVzdGluZy1mYXJtLmlvLzk3
+        ... YTdjYzI0LTY5MjYtNDA1OS04NGFjLWQwMDc4Mjk3YzMxOQo='''
+        >>> s = base64.b64decode(s).decode()
+        >>> TestingFarmWatchResult.from_output(s)
+        (<TestingFarmWatchResult.REQUEST_RUNNING: 'request is running'>, 'https://artifacts.dev.testing-farm.io/97a7cc24-6926-4059-84ac-d0078297c319')
         """
         string = clean_testing_farm_output(string)
         for watch_result in TestingFarmWatchResult.all_watch_results():

--- a/snapshot_manager/snapshot_manager/testing_farm_util.py
+++ b/snapshot_manager/snapshot_manager/testing_farm_util.py
@@ -200,6 +200,7 @@ class TestingFarmRequest:
             --arch {util.chroot_arch(chroot)} \
             --plan /tests/snapshot-gating \
             --environment COPR_PROJECT={config.copr_projectname} \
+            --environment COPR_CHROOT={chroot} \
             --context distro={util.chroot_os(chroot)} \
             --context arch={util.chroot_arch(chroot)} \
             --no-wait \

--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -11,7 +11,7 @@
 summary: LLVM Tests for snapshot gating
 prepare:
   - how: install
-    copr: "@fedora-llvm-team/$COPR_PROJECT"
+    copr: "@fedora-llvm-team/$COPR_PROJECT $COPR_CHROOT"
     # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
     # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
   - how: shell


### PR DESCRIPTION
Manually specify DNF copr repository

This should fix an issue when the tests are being executed on RHEL where
it seems that DNF by default looks for epel and not rhel chroots:

```
        Command 'dnf copr -y enable -y @fedora-llvm-team/llvm-snapshots-big-merge-20240523' returned 1.

        stderr (17 lines)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        stderr (17 lines)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        Enabling a Copr repository. Please note that this repository is not part
        of the main distribution, and quality may vary.

        The Fedora Project does not exercise any power over the contents of
        this repository beyond the rules outlined in the Copr FAQ at
        <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
        and packages are not held to any quality or security level.

        Please do not file bug reports about these packages in Fedora
        Bugzilla. In case of problems, contact the owner of this repository.
        Error: It wasn't possible to enable this project.
        Repository 'epel-9-x86_64' does not exist in project '@fedora-llvm-team/llvm-snapshots-big-merge-20240523'.
        Available repositories: 'fedora-39-s390x', 'fedora-38-i386', 'fedora-rawhide-aarch64', 'fedora-39-i386', 'fedora-38-x86_64', 'fedora-40-i386', 'fedora-38-s390x', 'fedora-rawhide-i386', 'fedora-40-x86_64', 'fedora-40-s390x', 'rhel-9-aarch64', 'fedora-39-ppc64le', 'fedora-rawhide-x86_64', 'fedora-40-ppc64le', 'rhel-9-x86_64', 'fedora-rawhide-s390x', 'fedora-39-x86_64', 'fedora-38-ppc64le', 'fedora-38-aarch64', 'rhel-9-s390x', 'fedora-39-aarch64', 'fedora-rawhide-ppc64le', 'fedora-40-aarch64'

        If you want to enable a non-default repository, use the following command:
          'dnf copr enable @fedora-llvm-team/llvm-snapshots-big-merge-20240523 <repository>'
        But note that the installed repo file will likely need a manual modification.
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fix #513
