### PR TITLE
Replace os/ and arch/ labels with build_failed_on/<chroot>

### DIFF
--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -120,7 +120,7 @@ we'll analyze the build log (if any) to identify the cause of the failure. The c
 For each cause we will list the packages and the relevant log excerpts.</dd>
 <dt>Use of labels</dt>
 <dd>Let's assume a unit test test in upstream LLVM was broken.
-We will then add these labels to this issue: <code>error/test</code>, <code>arch/x86_64</code>, <code>os/fedora-rawhide</code>, <code>project/llvm</code>.
+We will then add these labels to this issue: <code>error/test</code>, <code>build_failed_on/fedora-rawhide-x86_64</code>, <code>project/llvm</code>.
 If you manually restart a build in Copr and can bring it to a successful state, we will automatically
 remove the aforementioned labels.
 </dd>
@@ -242,11 +242,10 @@ remove the aforementioned labels.
     def get_error_label_names_on_issue(self, issue: github.Issue.Issue) -> list[str]:
         return self.get_label_names_on_issue(issue, prefix="error/")
 
-    def get_os_label_names_on_issue(self, issue: github.Issue.Issue) -> list[str]:
-        return self.get_label_names_on_issue(issue, prefix="os/")
-
-    def get_arch_label_names_on_issue(self, issue: github.Issue.Issue) -> list[str]:
-        return self.get_label_names_on_issue(issue, prefix="arch/")
+    def get_build_failed_on_names_on_issue(
+        self, issue: github.Issue.Issue
+    ) -> list[str]:
+        return self.get_label_names_on_issue(issue, prefix="build_failed_on/")
 
     def get_project_label_names_on_issue(self, issue: github.Issue.Issue) -> list[str]:
         return self.get_label_names_on_issue(issue, prefix="project/")
@@ -258,11 +257,11 @@ remove the aforementioned labels.
             labels=labels, prefix="error/", color="FBCA04", **kw_args
         )
 
-    def create_labels_for_oses(
+    def create_labels_for_build_failed_on(
         self, labels: list[str], **kw_args
     ) -> list[github.Label.Label]:
         return self.create_labels(
-            labels=labels, prefix="os/", color="F9D0C4", **kw_args
+            labels=labels, prefix="build_failed_on/", color="F9D0C4", **kw_args
         )
 
     def create_labels_for_projects(
@@ -277,13 +276,6 @@ remove the aforementioned labels.
     ) -> list[github.Label.Label]:
         return self.create_labels(
             labels=labels, prefix="strategy/", color="FFFFFF", *kw_args
-        )
-
-    def create_labels_for_archs(
-        self, labels: list[str], **kw_args
-    ) -> list[github.Label.Label]:
-        return self.create_labels(
-            labels=labels, prefix="arch/", color="C5DEF5", *kw_args
         )
 
     def create_labels_for_in_testing(

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -424,8 +424,9 @@ class SnapshotManager:
         logging.info("Gather labels based on the errors we've found")
         error_labels = list({f"error/{err.err_cause}" for err in errors})
         project_labels = list({f"project/{err.package_name}" for err in errors})
-        os_labels = list({f"os/{err.os}" for err in errors})
-        arch_labels = list({f"arch/{err.arch}" for err in errors})
+        build_failed_on_labels = list(
+            {f"build_failed_on/{err.chroot}" for err in errors}
+        )
         strategy_labels = [f"strategy/{self.config.build_strategy}"]
         llvm_release = util.get_release_for_yyyymmdd(self.config.yyyymmdd)
         other_labels: list[str] = [
@@ -439,9 +440,8 @@ class SnapshotManager:
             labels=["broken_snapshot_detected"], color="F46696", prefix=""
         )
         self.github.create_labels_for_error_causes(error_labels)
-        self.github.create_labels_for_oses(os_labels)
+        self.github.create_labels_for_build_failed_on(build_failed_on_labels)
         self.github.create_labels_for_projects(project_labels)
-        self.github.create_labels_for_archs(arch_labels)
         self.github.create_labels_for_strategies(strategy_labels)
         self.github.create_labels_for_in_testing(all_chroots)
         self.github.create_labels_for_tested_on(all_chroots)
@@ -455,11 +455,15 @@ class SnapshotManager:
         labels_to_be_removed: list[str] = []
         old_error_labels = self.github.get_error_label_names_on_issue(issue=issue)
         old_project_labels = self.github.get_project_label_names_on_issue(issue=issue)
-        old_arch_labels = self.github.get_arch_label_names_on_issue(issue=issue)
+        old_build_failed_labels = self.github.get_build_failed_on_names_on_issue(
+            issue=issue
+        )
 
         labels_to_be_removed.extend(set(old_error_labels) - set(error_labels))
         labels_to_be_removed.extend(set(old_project_labels) - set(project_labels))
-        labels_to_be_removed.extend(set(old_arch_labels) - set(arch_labels))
+        labels_to_be_removed.extend(
+            set(old_build_failed_labels) - set(build_failed_on_labels)
+        )
 
         for label in labels_to_be_removed:
             logging.info(f"Removing label that no longer applies: {label}")
@@ -469,8 +473,7 @@ class SnapshotManager:
         labels_to_add = (
             error_labels
             + project_labels
-            + os_labels
-            + arch_labels
+            + build_failed_on_labels
             + strategy_labels
             + other_labels
         )


### PR DESCRIPTION
The old `os/` and `arch/` labels will no longer be created. And are safe
to be deleted when working on #530.

Fix #529
