### PR TITLE
label: failed_on/<chroot> -> tests_failed_on/<chroot>

### DIFF
--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -66,7 +66,7 @@ class Config:
 
     label_prefix_in_testing: str = "in_testing/"
     label_prefix_tested_on: str = "tested_on/"
-    label_prefix_failed_on: str = "failed_on/"
+    label_prefix_tests_failed_on: str = "tests_failed_on/"
 
     label_prefix_llvm_release: str = "release/"
 

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -298,12 +298,12 @@ remove the aforementioned labels.
             *kw_args,
         )
 
-    def create_labels_for_failed_on(
+    def create_labels_for_tests_failed_on(
         self, labels: list[str], **kw_args
     ) -> list[github.Label.Label]:
         return self.create_labels(
             labels=labels,
-            prefix=self.config.label_prefix_failed_on,
+            prefix=self.config.label_prefix_tests_failed_on,
             color="D93F0B",
             *kw_args,
         )
@@ -502,7 +502,7 @@ remove the aforementioned labels.
         return f"{self.config.label_prefix_in_testing}{chroot}"
 
     def label_failed_on(self, chroot: str) -> str:
-        return f"{self.config.label_prefix_failed_on}{chroot}"
+        return f"{self.config.label_prefix_tests_failed_on}{chroot}"
 
     def label_tested_on(self, chroot: str) -> str:
         return f"{self.config.label_prefix_tested_on}{chroot}"

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -294,7 +294,7 @@ class SnapshotManager:
 
             in_testing = f"{self.config.label_prefix_in_testing}{chroot}"
             tested_on = f"{self.config.label_prefix_tested_on}{chroot}"
-            failed_on = f"{self.config.label_prefix_failed_on}{chroot}"
+            failed_on = f"{self.config.label_prefix_tests_failed_on}{chroot}"
 
             # Gather build IDs associated with this chroot.
             # We'll attach them a new testing-farm request, and for a recovered
@@ -445,7 +445,7 @@ class SnapshotManager:
         self.github.create_labels_for_strategies(strategy_labels)
         self.github.create_labels_for_in_testing(all_chroots)
         self.github.create_labels_for_tested_on(all_chroots)
-        self.github.create_labels_for_failed_on(all_chroots)
+        self.github.create_labels_for_tests_failed_on(all_chroots)
         self.github.create_labels_for_llvm_releases([llvm_release])
 
         # Remove old labels from issue if they no longer apply. This is great

--- a/snapshot_manager/tests/github_util_test.py
+++ b/snapshot_manager/tests/github_util_test.py
@@ -83,7 +83,7 @@ class TestGithub(base_test.TestBase):
         all_chroots = [chroot]
         logging.info("Creating test labels")
         gh.create_labels_for_in_testing(all_chroots)
-        gh.create_labels_for_failed_on(all_chroots)
+        gh.create_labels_for_tests_failed_on(all_chroots)
         gh.create_labels_for_tested_on(all_chroots)
 
         in_testing = gh.label_in_testing(chroot=chroot)


### PR DESCRIPTION
Fix #533
