### PR TITLE
Set correct url for llvm tmt tests repo

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -46,7 +46,7 @@ discover:
       filter: "tag:-spoils-installation & tag:-not-in-default"
     - name: llvm-tests
       how: fmf
-      url: https://src.fedoraproject.org/forks/kkleine/tests/llvm.git
+      url: https://src.fedoraproject.org/tests/llvm.git
       ref: main
       filter: "tag:-spoils-installation & tag:-not-in-default"
     - name: python-lit


### PR DESCRIPTION
It was set to a different repo while some issues were fixed, now it's safe to go back to the upstream.