### PR TITLE
Relax rpm__installed_but_unpackaged_files_found

### DIFF
--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -337,7 +337,7 @@ def get_cause_from_build_log(
 
     logging.info(" Checking for installed but unackaged files...")
     ret, ctx, _ = util.grep_file(
-        pattern=r"(?s)RPM build errors:\n.*    Installed \(but unpackaged\) file\(s\) found:.*Finish",
+        pattern=r"(?s)Installed \(but unpackaged\) file\(s\) found:.*Finish",
         extra_args="-Pzo",
         filepath=build_log_file,
     )

--- a/snapshot_manager/tests/test_logs/cause_rpm__installed_but_unpackaged_files_found.golden.txt
+++ b/snapshot_manager/tests/test_logs/cause_rpm__installed_but_unpackaged_files_found.golden.txt
@@ -1,5 +1,10 @@
 
 ```
+Installed (but unpackaged) file(s) found:
+   /usr/lib/debug/usr/lib64/libomptarget.rtl.s390x.so.19.0pre20240320.gf5f3d5d6534f0a-19.0.0~pre20240320.gf5f3d5d6534f0a-1.fc38.s390x.debug
+   /usr/lib64/libomptarget.rtl.s390x.so
+   /usr/lib64/libomptarget.rtl.s390x.so.19.0pre20240320.gf5f3d5d6534f0a
+
 RPM build errors:
     Installed (but unpackaged) file(s) found:
    /usr/lib/debug/usr/lib64/libomptarget.rtl.s390x.so.19.0pre20240320.gf5f3d5d6534f0a-19.0.0~pre20240320.gf5f3d5d6534f0a-1.fc38.s390x.debug


### PR DESCRIPTION
We assumed that `RPM build Errors:` would always appear before the
`Installed (but unpackaged) file(s) found:` but it sometimes doesn't.
This relaxes the detection a bit in order to discover this error more
accurately.
