### PR TITLE
Enable module hotfixes option

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -127,6 +127,7 @@ jobs:
             --multilib on \
             --appstream off \
             --delete-after-days 32 \
+            --module-hotfixes on \
             $chroot_opts "${{ env.project_today }}"
 
       - name: "Enable swig:4.0 module in RHEL 8 build chroots (if any)"


### PR DESCRIPTION
This will prefer the LLVM packages from the copr repo over the llvm-toolset module stream from the RHEL repo.