### PR TITLE
Change how build failure comments are generated

### DIFF
--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -168,7 +168,7 @@ remove the aforementioned labels.
         if maintainer_handle is not None:
             opts["assignee"] = maintainer_handle
         issue = repo.create_issue(
-            title=self.issue_title(), body=self.initial_comment, *opts
+            title=self.issue_title(), body=self.initial_comment, **opts
         )
         self.create_labels_for_strategies(labels=[strategy])
         issue.add_to_labels(f"strategy/{strategy}")

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -106,8 +106,6 @@ class GithubClient:
         llvm_release = util.get_release_for_yyyymmdd(self.config.yyyymmdd)
         llvm_git_revision = util.get_git_revision_for_yyyymmdd(self.config.yyyymmdd)
         return f"""
-Hello @{self.config.maintainer_handle}!
-
 <p>
 This issue exists to let you know that we are about to monitor the builds
 of the LLVM (v{llvm_release}, <a href="https://github.com/llvm/llvm-project/commit/{llvm_git_revision}">llvm/llvm-project@ {llvm_git_revision[:7]}</a>) snapshot for <a href="{self.config.copr_monitor_url}">{self.config.yyyymmdd}</a>.
@@ -149,7 +147,6 @@ remove the aforementioned labels.
 
     def create_or_get_todays_github_issue(
         self,
-        maintainer_handle: str = None,
         creator: str = "github-actions[bot]",
     ) -> tuple[github.Issue.Issue, bool]:
         issue = self.get_todays_github_issue(
@@ -165,11 +162,7 @@ remove the aforementioned labels.
         logging.info("Creating issue for today")
 
         opts = {}
-        if maintainer_handle is not None:
-            opts["assignee"] = maintainer_handle
-        issue = repo.create_issue(
-            title=self.issue_title(), body=self.initial_comment, **opts
-        )
+        issue = repo.create_issue(title=self.issue_title(), body=self.initial_comment)
         self.create_labels_for_strategies(labels=[strategy])
         issue.add_to_labels(f"strategy/{strategy}")
         return (issue, True)

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -161,7 +161,6 @@ remove the aforementioned labels.
         repo = self.gh_repo
         logging.info("Creating issue for today")
 
-        opts = {}
         issue = repo.create_issue(title=self.issue_title(), body=self.initial_comment)
         self.create_labels_for_strategies(labels=[strategy])
         issue.add_to_labels(f"strategy/{strategy}")

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -149,7 +149,7 @@ remove the aforementioned labels.
 
     def create_or_get_todays_github_issue(
         self,
-        maintainer_handle: str,
+        maintainer_handle: str = None,
         creator: str = "github-actions[bot]",
     ) -> tuple[github.Issue.Issue, bool]:
         issue = self.get_todays_github_issue(
@@ -164,10 +164,11 @@ remove the aforementioned labels.
         repo = self.gh_repo
         logging.info("Creating issue for today")
 
+        opts = {}
+        if maintainer_handle is not None:
+            opts["assignee"] = maintainer_handle
         issue = repo.create_issue(
-            assignee=maintainer_handle,
-            title=self.issue_title(),
-            body=self.initial_comment,
+            title=self.issue_title(), body=self.initial_comment, *opts
         )
         self.create_labels_for_strategies(labels=[strategy])
         issue.add_to_labels(f"strategy/{strategy}")

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -165,7 +165,6 @@ class SnapshotManager:
     def check_todays_builds(self) -> None:
         """This method is driven from the config settings"""
         issue, issue_is_newly_created = self.github.create_or_get_todays_github_issue(
-            maintainer_handle=self.config.maintainer_handle,
             creator=self.config.creator_handle,
         )
         # if issue.state == "closed":
@@ -183,6 +182,9 @@ class SnapshotManager:
             for chroot in all_chroots:
                 comment = issue.create_comment(f"<!--ERRORS_FOR_CHROOT/{chroot}-->")
                 self.github.minimize_comment_as_outdated(comment)
+            # Only assign the issue now so that there are no notifications for
+            # all the error comments we've just created.
+            issue.add_to_assignees(self.config.maintainer_handle)
 
         logging.info("Get build states from copr")
         states = self.copr.get_build_states_from_copr_monitor(

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -178,7 +178,7 @@ class SnapshotManager:
         if issue_is_newly_created:
             # The issue was newly created so we'll create comments for each
             # chroot that we care about and hide them for now. Then humanly
-            # created output will be come at the end always.
+            # created output will always come at the end.
             for chroot in all_chroots:
                 comment = issue.create_comment(f"<!--ERRORS_FOR_CHROOT/{chroot}-->")
                 self.github.minimize_comment_as_outdated(comment)

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -164,7 +164,7 @@ class SnapshotManager:
 
     def check_todays_builds(self) -> None:
         """This method is driven from the config settings"""
-        issue, _ = self.github.create_or_get_todays_github_issue(
+        issue, issue_is_newly_created = self.github.create_or_get_todays_github_issue(
             maintainer_handle=self.config.maintainer_handle,
             creator=self.config.creator_handle,
         )
@@ -175,6 +175,14 @@ class SnapshotManager:
         #     return
 
         all_chroots = self.copr.get_copr_chroots()
+
+        if issue_is_newly_created:
+            # The issue was newly created so we'll create comments for each
+            # chroot that we care about and hide them for now. Then humanly
+            # created output will be come at the end always.
+            for chroot in all_chroots:
+                comment = issue.create_comment(f"<!--ERRORS_FOR_CHROOT/{chroot}-->")
+                self.github.minimize_comment_as_outdated(comment)
 
         logging.info("Get build states from copr")
         states = self.copr.get_build_states_from_copr_monitor(
@@ -234,20 +242,6 @@ class SnapshotManager:
                 new_requests[chroot] = requests[chroot]
         requests = new_requests
 
-        # Hide/Unhide all unused/used chroot error comments if they belong to a chroot we don't care about
-        for comment in issue.get_comments():
-            logging.info("checking for <!--ERRORS_FOR_CHROOT/")
-            match = re.search(r"<!--ERRORS_FOR_CHROOT/(.*)-->", comment.body)
-            if match:
-                chroot = match.group(1)
-                logging.info(f"found match: chroot={chroot}")
-                if chroot not in self.copr.get_copr_chroots():
-                    logging.info("minimizing comment")
-                    self.github.minimize_comment_as_outdated(comment)
-                else:
-                    logging.info("unminimizing comment")
-                    self.github.unminimize_comment(comment)
-
         # logging.info(f"Update the issue comment body")
         # # See https://github.com/fedora-llvm-team/llvm-snapshots/issues/205#issuecomment-1902057639
         # max_length = 65536
@@ -276,6 +270,7 @@ class SnapshotManager:
 {build_status.render_as_markdown(errors_for_this_chroot)}
 """,
                 )
+                self.github.unminimize_comment(comment)
                 build_status_matrix = build_status_matrix.replace(
                     chroot,
                     f'{chroot}<br /> :x: <a href="{comment.html_url}">Copr build(s) failed</a>',

--- a/snapshot_manager/tests/github_util_test.py
+++ b/snapshot_manager/tests/github_util_test.py
@@ -13,9 +13,7 @@ class TestGithub(base_test.TestBase):
     def test_create_or_get_todays_github_issue(self):
         """Creates or gets today's github issue"""
         gh = github_util.GithubClient(config=self.config)
-        issue, _ = gh.create_or_get_todays_github_issue(
-            maintainer_handle="kwk", creator="kwk"
-        )
+        issue, _ = gh.create_or_get_todays_github_issue(creator="kwk")
         self.assertIsNotNone(issue)
 
         marker = "<!--HIDE_COMMMENT-->"


### PR DESCRIPTION
1. Upon issue creation we create minimized comments for all chroots and
   mark them with i.e. `<!--ERRORS_FOR_CHROOT/fedora-rawhide-x86_64-->`.
2. When we find an error in a chroot we update the above created comment
   and unminimize it.
3. In case when there's no error for a chroot, we're gonna minimize the
   comment again.

Fixes #626
