### PR TITLE
Downgrade testing-farm to 0.0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,10 +85,6 @@ requests-toolbelt==1.0.0
     # via copr
 rich==12.6.0
     # via typer
-ruamel-yaml==0.18.6
-    # via tft-cli
-ruamel-yaml-clib==0.2.8
-    # via ruamel-yaml
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -97,7 +93,7 @@ six==1.16.0
     #   python-dateutil
 tenacity==8.2.3
     # via plotly
-tft-cli==0.0.18
+tft-cli==0.0.16
     # via -r requirements.txt.in
 typer[all]==0.7.0
     # via tft-cli

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -7,7 +7,7 @@ PyGithub==2.3.0
 pandas
 plotly==5.23.0
 copr-cli
-tft-cli==0.0.18
+tft-cli==0.0.16
 regex==2024.7.24
 munch==4.0.0
 copr==1.132


### PR DESCRIPTION
This should allow us to get artifact URLs pointing to testing-farm results on the redhat ranch.

In 0.0.18 or before, testing-farm introduced more detailed output in the
`testing-farm watch` command which required to make calls that at least
the redhat ranch were only possible in the Red Hat VPN which is not
possible on github.
