### PR TITLE
Fix TestTestingFarmUtil.test_fetch_failed_test_cases_from_file

### DIFF
--- a/snapshot_manager/tests/testing-farm-logs/output_1f25b0df-71f1-4a13-a4b8-c066f6f5f116.txt
+++ b/snapshot_manager/tests/testing-farm-logs/output_1f25b0df-71f1-4a13-a4b8-c066f6f5f116.txt
@@ -1,0 +1,4 @@
++ clang -m32 -fsanitize=address test.c
+/usr/bin/ld: cannot find -lgcc_s: No such file or directory
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+Shared connection to 3.12.104.11 closed.

--- a/snapshot_manager/tests/testing_farm_util_test.py
+++ b/snapshot_manager/tests/testing_farm_util_test.py
@@ -13,6 +13,7 @@ class TestTestingFarmUtil(base_test.TestBase):
             request_id=request_id,
             chroot=chroot,
             copr_build_ids=[11, 22, 33],
+            _in_test_mode=True,
         )
         actual = req.get_failed_test_cases_from_xunit_file(
             xunit_file=self.abspath(f"testing-farm-logs/results_{request_id}.xml"),


### PR DESCRIPTION
`TestingFarmRequest` now can be put into test-mode which allows to fetch
failed test cases from file rather than URL.

Fixes #632
