### PR TITLE
Add visible comment to initially hidden chroot placeholder comments and reduce notifications.

### DIFF
--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -180,7 +180,9 @@ class SnapshotManager:
             # chroot that we care about and hide them for now. Then humanly
             # created output will always come at the end.
             for chroot in all_chroots:
-                comment = issue.create_comment(f"<!--ERRORS_FOR_CHROOT/{chroot}-->")
+                comment = issue.create_comment(
+                    f"<!--ERRORS_FOR_CHROOT/{chroot}--> This is a placeholder for any errors that might happen for the `{chroot}` chroot."
+                )
                 self.github.minimize_comment_as_outdated(comment)
             # Only assign the issue now so that there are no notifications for
             # all the error comments we've just created.

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -184,6 +184,8 @@ class SnapshotManager:
                     f"<!--ERRORS_FOR_CHROOT/{chroot}--> This is a placeholder for any errors that might happen for the `{chroot}` chroot."
                 )
                 self.github.minimize_comment_as_outdated(comment)
+
+        else:
             # Only assign the issue now so that there are no notifications for
             # all the error comments we've just created.
             issue.add_to_assignees(self.config.maintainer_handle)


### PR DESCRIPTION
* [Add visible comment to initially hidden chroot placeholder comments](https://github.com/fedora-llvm-team/llvm-snapshots/pull/643/commits/908f051a4a5a3655693f1e1f5fc3156fbe852a85)
* [Only assign maintainer from second check run onwards](https://github.com/fedora-llvm-team/llvm-snapshots/pull/643/commits/064b02ac55743bb7789a00530562b05bcfcdd2d6) (to reduce notifications)