### PR TITLE
Show error results expanded by default one level down

### DIFF
--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -105,7 +105,7 @@ class BuildState:
         if self.url_build_log is None:
             link = f'<a href="{self.build_page_url}">build page</a>'
         return f"""
-<details>
+<details open>
 <summary>
 <code>{self.package_name}</code> on <code>{self.chroot}</code> (see {link})
 </summary>

--- a/snapshot_manager/tests/build_status_test.py
+++ b/snapshot_manager/tests/build_status_test.py
@@ -101,7 +101,7 @@ class TestErrorCauseAndBuildStatus(base_test.TestBase):
         )
 
         expected = """
-<details>
+<details open>
 <summary>
 <code>foo</code> on <code>fedora-40-x86_64</code> (see <a href="https://example.com/url_build_log">build log</a>, <a href="https://logdetective.com/contribute/copr/00001234/fedora-40-x86_64">contribute to log-detective</a>)
 </summary>
@@ -152,42 +152,42 @@ class TestErrorList(base_test.TestBase):
         actual = build_status.render_as_markdown(unsorted)
 
         expected = """<ul><li><b>network_issue</b><ol><li>
-<details>
+<details open>
 <summary>
 <code>package-a</code> on <code>chroot-a</code> (see <a href="http://e1">build log</a>, <a href="https://logdetective.com/contribute/copr/00000111/chroot-a">contribute to log-detective</a>)
 </summary>
 e1
 </details>
 </li><li>
-<details>
+<details open>
 <summary>
 <code>package-b</code> on <code>chroot-a</code> (see <a href="http://e2">build log</a>, <a href="https://logdetective.com/contribute/copr/00000222/chroot-a">contribute to log-detective</a>)
 </summary>
 e2
 </details>
 </li><li>
-<details>
+<details open>
 <summary>
 <code>package-c</code> on <code>chroot-a</code> (see <a href="http://e3">build log</a>, <a href="https://logdetective.com/contribute/copr/00000333/chroot-a">contribute to log-detective</a>)
 </summary>
 e3
 </details>
 </li></ol></li><li><b>test</b><ol><li>
-<details>
+<details open>
 <summary>
 <code>package-a</code> on <code>chroot-c</code> (see <a href="http://e4">build log</a>, <a href="https://logdetective.com/contribute/copr/00000444/chroot-c">contribute to log-detective</a>)
 </summary>
 e4
 </details>
 </li><li>
-<details>
+<details open>
 <summary>
 <code>package-b</code> on <code>chroot-c</code> (see <a href="http://e5">build log</a>, <a href="https://logdetective.com/contribute/copr/00000555/chroot-c">contribute to log-detective</a>)
 </summary>
 e5
 </details>
 </li><li>
-<details>
+<details open>
 <summary>
 <code>package-c</code> on <code>chroot-c</code> (see <a href="http://e6">build log</a>, <a href="https://logdetective.com/contribute/copr/00000666/chroot-c">contribute to log-detective</a>)
 </summary>


### PR DESCRIPTION
# Motivation

I wanted to see at a glance which tests are failing without having the need to click the expander. I don't want to see the exact error for each test but just the name of the test that was failing.

# Before

![Screenshot from 2024-08-19 09-48-47](https://github.com/user-attachments/assets/72762b64-aff8-4e90-92b5-a52d9b9521a8)

# With this change

![Screenshot from 2024-08-19 09-48-55](https://github.com/user-attachments/assets/a6a674d5-b26b-436f-9749-f90c9b8a454b)
