### PR TITLE
Handle exception when making testing-farm request

### DIFF
--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -368,17 +368,23 @@ class SnapshotManager:
                     self.github.flip_test_label(issue, chroot, in_testing)
             else:
                 logging.info(f"Starting tests for chroot {chroot}")
-                request = tf.TestingFarmRequest.make(
-                    chroot=chroot,
-                    config=self.config,
-                    issue=issue,
-                    copr_build_ids=current_copr_build_ids,
-                )
-                logging.info(
-                    f"testing-farm request ID for {chroot}: {request.request_id}"
-                )
-                requests[chroot] = request
-                self.github.flip_test_label(issue, chroot, in_testing)
+                try:
+                    request = tf.TestingFarmRequest.make(
+                        chroot=chroot,
+                        config=self.config,
+                        issue=issue,
+                        copr_build_ids=current_copr_build_ids,
+                    )
+                except Exception as ex:
+                    logging.warning(
+                        f"testing-farm request for {chroot} failed with: {ex}"
+                    )
+                else:
+                    logging.info(
+                        f"testing-farm request ID for {chroot}: {request.request_id}"
+                    )
+                    requests[chroot] = request
+                    self.github.flip_test_label(issue, chroot, in_testing)
 
             # Create or update a comment for testing-farm results display
             if len(failed_test_cases) > 0:

--- a/snapshot_manager/tests/testing_farm_util_test.py
+++ b/snapshot_manager/tests/testing_farm_util_test.py
@@ -19,15 +19,13 @@ class TestTestingFarmUtil(base_test.TestBase):
             strategy="big-merge", github_repo="fedora-llvm-team/llvm-snapshots"
         )
 
-        self.assertRaises(
-            SystemError,
+        with self.assertRaises(SystemError):
             tf.TestingFarmRequest.make(
                 chroot="fedora-900-x86_64",
                 config=self.config,
                 issue=issue,
                 copr_build_ids=[1, 2, 3],
-            ),
-        )
+            )
 
     def test_fetch_failed_test_cases_from_file(self):
         request_id = "1f25b0df-71f1-4a13-a4b8-c066f6f5f116"

--- a/snapshot_manager/tests/testing_farm_util_test.py
+++ b/snapshot_manager/tests/testing_farm_util_test.py
@@ -1,11 +1,34 @@
 """ Tests for build_status """
 
+import datetime
+
 import tests.base_test as base_test
 
+import snapshot_manager.github_util as github_util
 import snapshot_manager.testing_farm_util as tf
 
 
 class TestTestingFarmUtil(base_test.TestBase):
+    def test_make_with_missing_compose(self):
+        cfg = self.config
+        cfg.datetime = datetime.datetime(year=2024, month=2, day=27)
+        self.assertEqual("20240227", cfg.yyyymmdd)
+        gh = github_util.GithubClient(config=cfg)
+
+        issue = gh.get_todays_github_issue(
+            strategy="big-merge", github_repo="fedora-llvm-team/llvm-snapshots"
+        )
+
+        self.assertRaises(
+            SystemError,
+            tf.TestingFarmRequest.make(
+                chroot="fedora-900-x86_64",
+                config=self.config,
+                issue=issue,
+                copr_build_ids=[1, 2, 3],
+            ),
+        )
+
     def test_fetch_failed_test_cases_from_file(self):
         request_id = "1f25b0df-71f1-4a13-a4b8-c066f6f5f116"
         chroot = "fedora-39-x86_64"


### PR DESCRIPTION
We also add an exception that checks the exception is really thrown if a
compose is determined that doesn't exist.
