### PR TITLE
Workaround dnf5 copr issue in snapshot-gating tmt plan

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -10,10 +10,15 @@
 
 summary: LLVM Tests for snapshot gating
 prepare:
-  - how: install
-    copr: "@fedora-llvm-team/$COPR_PROJECT $COPR_CHROOT"
-    # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
-    # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
+  # dnf5's copr plugin has trouble resolving the runtime dependency repos, so
+  # we need to use dnf4. Check https://github.com/fedora-copr/copr/issues/3387
+  - name: Enable copr repo
+    how: shell
+    script: |
+      dnf install -y dnf-plugins-core
+      dnf-3 -y copr enable @fedora-llvm-team/$COPR_PROJECT $COPR_CHROOT
+  # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
+  # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
   - how: shell
     script: |
       dnf install -y dnf-plugins-core


### PR DESCRIPTION
dnf5 copr plugin has problems resolving the distname variable that we use in our Runtime dependency repos. This is needed to be able to use both fedora and rhel chroots. We will use dnf4 until the issue with dnf5 is resolved.

Related upstream issue: https://github.com/fedora-copr/copr/issues/3387