### PR TITLE
compare the system llvm against "big-merge" and "pgo"

### DIFF
--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:rawhide
 LABEL description="Test compilers with llvm-test-suite"
 
 USER root
@@ -25,8 +25,6 @@ RUN dnf install -y \
         tcl \
         tcl-devel \
         tcl-tclreadline \
-        tcl-tclxml \
-        tcl-tclxml-devel \
         tcl-thread-devel \
         tcl-zlib \
         which

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -1,0 +1,42 @@
+FROM fedora:40
+LABEL description="Test compilers with llvm-test-suite"
+
+USER root
+WORKDIR /root
+
+# Install deps to run test-suite
+RUN dnf install -y \
+        cmake \
+        fedora-packager \
+        git \
+        python3-pip \
+        python3-virtualenv \
+        python3-lit \
+        ninja-build \
+        which \
+        coreutils \
+        tcl \
+        tcl-devel \
+        tcl-tclreadline \
+        tcl-tclxml-devel \
+        tcl-tclxml \
+        tcl-zlib \
+        tcl-thread-devel
+
+RUN virtualenv ~/mysandbox
+RUN source ~/mysandbox/bin/activate \
+    && pip install \
+        pandas \
+        scipy
+
+# Clone test suite (in correct version for installed clang version)
+# See https://llvm.org/docs/TestSuiteGuide.html
+# RUN export VERSION=`clang --version | grep -ioP 'clang version\s\K[0-9\.]+'` \
+#     && git clone --depth=1 --branch llvmorg-${VERSION} https://github.com/llvm/llvm-test-suite.git test-suite
+RUN git clone --depth=1 https://github.com/llvm/llvm-test-suite.git test-suite
+
+RUN dnf install -y 'dnf-command(copr)' perf
+
+COPY entrypoint.sh /root/entrypoint.sh
+USER root
+ENTRYPOINT [ "/root/entrypoint.sh" ]

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:41
 LABEL description="Test compilers with llvm-test-suite"
 
 USER root
@@ -24,10 +24,13 @@ RUN dnf install -y \
         tcl-thread-devel
 
 RUN virtualenv ~/mysandbox
-RUN source ~/mysandbox/bin/activate \
-    && pip install \
-        pandas \
-        scipy
+RUN dnf install -y clang
+RUN dnf install -y python3-pandas python3-scipy
+RUN dnf install -y jq envsubst
+#RUN source ~/mysandbox/bin/activate \
+#    && pip install \
+#        pandas \
+#        scipy
 
 # Clone test suite (in correct version for installed clang version)
 # See https://llvm.org/docs/TestSuiteGuide.html

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -15,7 +15,6 @@ RUN dnf install -y \
         jq \
         jq \
         ninja-build \
-         \
         python3-lit \
         python3-pandas \
         python3-pip \

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -15,11 +15,11 @@ RUN dnf install -y \
         jq \
         jq \
         ninja-build \
-        perf
+        perf \
         python3-lit \
         python3-pandas \
         python3-pip \
-        python3-scipy
+        python3-scipy \
         python3-setuptools \
         python3-virtualenv \
         tcl \
@@ -29,7 +29,7 @@ RUN dnf install -y \
         tcl-tclxml-devel \
         tcl-thread-devel \
         tcl-zlib \
-        which \
+        which
 
 # Clone test suite (in correct version for installed clang version)
 # See https://llvm.org/docs/TestSuiteGuide.html

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -5,7 +5,9 @@ USER root
 WORKDIR /root
 
 # Install deps to run test-suite
-RUN dnf install -y \
+RUN dnf install -y 'dnf-command(copr)' \
+    && dnf copr enable -y @fedora-llvm-team/llvm-test-suite \
+    && dnf install -y \
         clang \
         cmake \
         coreutils \
@@ -14,6 +16,7 @@ RUN dnf install -y \
         git \
         jq \
         jq \
+        llvm-test-suite \
         ninja-build \
         python3-lit \
         python3-pandas \
@@ -27,10 +30,6 @@ RUN dnf install -y \
         tcl-thread-devel \
         tcl-zlib \
         which
-
-RUN dnf install -y 'dnf-command(copr)'
-RUN dnf copr enable -y @fedora-llvm-team/llvm-test-suite
-RUN dnf install -y llvm-test-suite
 
 COPY entrypoint.sh /root/entrypoint.sh
 USER root

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -15,7 +15,7 @@ RUN dnf install -y \
         jq \
         jq \
         ninja-build \
-        perf \
+         \
         python3-lit \
         python3-pandas \
         python3-pip \
@@ -29,13 +29,9 @@ RUN dnf install -y \
         tcl-zlib \
         which
 
-# Clone test suite (in correct version for installed clang version)
-# See https://llvm.org/docs/TestSuiteGuide.html
-# RUN export VERSION=`clang --version | grep -ioP 'clang version\s\K[0-9\.]+'` \
-#     && git clone --depth=1 --branch llvmorg-${VERSION} https://github.com/llvm/llvm-test-suite.git test-suite
-RUN git clone --depth=1 https://github.com/llvm/llvm-test-suite.git test-suite
-
 RUN dnf install -y 'dnf-command(copr)'
+RUN dnf copr enable -y @fedora-llvm-team/llvm-test-suite
+RUN dnf install -y llvm-test-suite
 
 COPY entrypoint.sh /root/entrypoint.sh
 USER root

--- a/scripts/perf/Containerfile
+++ b/scripts/perf/Containerfile
@@ -6,31 +6,30 @@ WORKDIR /root
 
 # Install deps to run test-suite
 RUN dnf install -y \
+        clang \
         cmake \
+        coreutils \
+        envsubst \
         fedora-packager \
         git \
-        python3-pip \
-        python3-virtualenv \
-        python3-lit \
+        jq \
+        jq \
         ninja-build \
-        which \
-        coreutils \
+        perf
+        python3-lit \
+        python3-pandas \
+        python3-pip \
+        python3-scipy
+        python3-setuptools \
+        python3-virtualenv \
         tcl \
         tcl-devel \
         tcl-tclreadline \
-        tcl-tclxml-devel \
         tcl-tclxml \
+        tcl-tclxml-devel \
+        tcl-thread-devel \
         tcl-zlib \
-        tcl-thread-devel
-
-RUN virtualenv ~/mysandbox
-RUN dnf install -y clang
-RUN dnf install -y python3-pandas python3-scipy
-RUN dnf install -y jq envsubst
-#RUN source ~/mysandbox/bin/activate \
-#    && pip install \
-#        pandas \
-#        scipy
+        which \
 
 # Clone test suite (in correct version for installed clang version)
 # See https://llvm.org/docs/TestSuiteGuide.html
@@ -38,7 +37,7 @@ RUN dnf install -y jq envsubst
 #     && git clone --depth=1 --branch llvmorg-${VERSION} https://github.com/llvm/llvm-test-suite.git test-suite
 RUN git clone --depth=1 https://github.com/llvm/llvm-test-suite.git test-suite
 
-RUN dnf install -y 'dnf-command(copr)' perf
+RUN dnf install -y 'dnf-command(copr)'
 
 COPY entrypoint.sh /root/entrypoint.sh
 USER root

--- a/scripts/perf/Makefile
+++ b/scripts/perf/Makefile
@@ -1,4 +1,4 @@
 .PHONY: all
 all:
 	podman build -t evaluation .
-	podman run -it evaluation
+	podman run -it --rm evaluation

--- a/scripts/perf/Makefile
+++ b/scripts/perf/Makefile
@@ -1,4 +1,10 @@
 .PHONY: all
-all:
+all: setup run
+
+.PHONY: setup
+setup:
 	podman build -t evaluation .
+
+.PHONY: run
+run:
 	podman run -it --rm evaluation

--- a/scripts/perf/Makefile
+++ b/scripts/perf/Makefile
@@ -1,0 +1,4 @@
+.PHONY: all
+all:
+	podman build -t evaluation .
+	podman run -it evaluation

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,27 +1,11 @@
 # README
 
-This container setup allows you to compare the system llvm against "big-merge" and "pgo".
+This container setup allows you to compare the system llvm against "big-merge" and "pgo" for the current date.
 
 # How to
 
 Just run `make` to build and run the container image. It takes a long time to complete.
 
-Then you'll be promted to a terminal in the container where you'll find these files:
+Then you'll be promted with a markdown output that you can copy and paste into a github issue.
 
-```
-~/results-system-vs-pgo.txt
-~/results-system-vs-big-merge.txt
-~/results-big-merge-vs-pgo.txt
-```
-
-The names speak for themselves.
-
-## How to change to OS
-
-If you want to change the version of the operating system, go to `Containerfile` and change the line that looks like this: `FROM fedora:40`. Change it to `FROM fedora:41` or something else.
-
-Then run `make` again.
-
-## How to change the date for which to compare results?
-
-Go to `entrypoint.sh` and change the line that defines `yyyymmdd` to the year-month-date of your liking.
+The output is located between `<!--BEGIN REPORT-->` and `<!--END REPORT-->` markers.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -7,6 +7,6 @@ system llvm against "big-merge" (aka snapshot) and "pgo" for the current date.
 
 Just run `make` to build and run the container image. It takes a long time to complete.
 
-Then you'll be promted with a markdown output that you can copy and paste into a github issue.
+Then you'll be prompted with a markdown output that you can copy and paste into a github issue.
 
 The output is located between `<!--BEGIN REPORT-->` and `<!--END REPORT-->` markers.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,27 @@
+# README
+
+This container setup allows you to compare the system llvm against "big-merge" and "pgo".
+
+# How to
+
+Just run `make` to build and run the container image. It takes a long time to complete.
+
+Then you'll be promted to a terminal in the container where you'll find these files:
+
+```
+~/results-system-vs-pgo.txt
+~/results-system-vs-big-merge.txt
+~/results-big-merge-vs-pgo.txt
+```
+
+The names speak for themselves.
+
+## How to change to OS
+
+If you want to change the version of the operating system, go to `Containerfile` and change the line that looks like this: `FROM fedora:40`. Change it to `FROM fedora:41` or something else.
+
+Then run `make` again.
+
+## How to change the date for which to compare results?
+
+Go to `entrypoint.sh` and change the line that defines `yyyymmdd` to the year-month-date of your liking.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,6 +1,7 @@
 # README
 
-This container setup allows you to compare the system llvm against "big-merge" and "pgo" for the current date.
+This container setup allows you to compare compile time performance of the
+system llvm against "big-merge" (aka snapshot) and "pgo" for the current date.
 
 # How to
 

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -12,6 +12,9 @@ function configure_build_run {
         -DCMAKE_GENERATOR=Ninja \
         -DCMAKE_C_COMPILER=/usr/bin/clang \
         -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+        -DTEST_SUITE_BENCHMARKING_ONLY=ON \
+        -DTEST_SUITE_COLLECT_STATS=ON \
+        -DTEST_SUITE_USE_PERF=ON \
         -C~/test-suite/cmake/caches/O3.cmake \
         ~/test-suite
 
@@ -23,7 +26,7 @@ function configure_build_run {
 }
 
 # Query version information for given day
-yyyymmdd=20240909
+yyyymmdd=20240911
 git_rev=$(curl -sL https://github.com/fedora-llvm-team/llvm-snapshots/releases/download/snapshot-version-sync/llvm-git-revision-${yyyymmdd}.txt)
 git_rev_short="${git_rev:0:14}"
 llvm_release=$(curl -sL https://github.com/fedora-llvm-team/llvm-snapshots/releases/download/snapshot-version-sync/llvm-release-${yyyymmdd}.txt)

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -40,7 +40,7 @@ echo "rpm_suffix=$rpm_suffix"
 # Install and enable the repository that provides the PGO LLVM Toolchain
 # See https://llvm.org/docs/HowToBuildWithPGO.html#building-clang-with-pgo
 dnf copr enable -y @fedora-llvm-team/llvm-snapshots-pgo-${yyyymmdd}
-dnf install -y \
+dnf -y repository-packages copr:copr.fedorainfracloud.org:group_fedora-llvm-team:llvm-snapshots-pgo-${yyyymmdd} install \
     clang-${rpm_suffix} \
     clang-${rpm_suffix} \
     clang-libs-${rpm_suffix} \
@@ -62,7 +62,7 @@ dnf -y copr remove @fedora-llvm-team/llvm-snapshots-pgo-${yyyymmdd}
 
 # Install and enable the repository that provides the big-merge LLVM Toolchain
 dnf copr enable -y @fedora-llvm-team/llvm-snapshots-big-merge-${yyyymmdd}
-dnf install -y \
+dnf -y repository-packages copr:copr.fedorainfracloud.org:group_fedora-llvm-team:llvm-snapshots-big-merge-${yyyymmdd} install \
     clang-${rpm_suffix} \
     clang-${rpm_suffix} \
     clang-libs-${rpm_suffix} \

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 function configure_build_run {
     # Configure the test suite
     cmake \
-        -DCMAKE_GENERATOR=Ninja \
+        -GNinja \
         -DCMAKE_C_COMPILER=/usr/bin/clang \
         -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
         -DTEST_SUITE_BENCHMARKING_ONLY=ON \

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -11,7 +11,7 @@ function configure_build_run {
         -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
         -DTEST_SUITE_BENCHMARKING_ONLY=ON \
         -DTEST_SUITE_COLLECT_STATS=ON \
-        -DTEST_SUITE_USE_PERF=ON \
+        -DTEST_SUITE_USE_PERF=OFF \
         -DTEST_SUITE_SUBDIRS=CTMark \
         -DTEST_SUITE_RUN_BENCHMARKS=OFF \
         -C~/test-suite/cmake/caches/O3.cmake \

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -12,6 +12,7 @@ function configure_build_run {
         -DTEST_SUITE_BENCHMARKING_ONLY=ON \
         -DTEST_SUITE_COLLECT_STATS=ON \
         -DTEST_SUITE_USE_PERF=ON \
+        -DTEST_SUITE_SUBDIRS=CTMark \
         -DTEST_SUITE_RUN_BENCHMARKS=OFF \
         -C~/test-suite/cmake/caches/O3.cmake \
         ~/test-suite
@@ -104,23 +105,20 @@ system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head 
 
 /root/test-suite/utils/compare.py \
     --metric compile_time \
-    --metric link_time \
     --lhs-name ${system_llvm_release} \
-    --rhs-name pgo \
+    --rhs-name pgo-${yyyymmdd} \
     ~/system/results.json vs ~/pgo/results.json > ~/results-system-vs-pgo.txt || true
 
 /root/test-suite/utils/compare.py \
     --metric compile_time \
-    --metric link_time \
     --lhs-name ${system_llvm_release} \
-    --rhs-name big-merge} \
+    --rhs-name big-merge-${yyyymmdd} \
     ~/system/results.json vs ~/big-merge/results.json > ~/results-system-vs-big-merge.txt || true
 
 /root/test-suite/utils/compare.py \
     --metric compile_time \
-    --metric link_time \
     --lhs-name big-merge \
-    --rhs-name pgo \
+    --rhs-name pgo-${yyyymmdd} \
     ~/big-merge/results.json vs ~/pgo/results.json > ~/results-big-merge-vs-pgo.txt || true
 
 bash

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -12,14 +12,15 @@ function configure_build_run {
         -DTEST_SUITE_BENCHMARKING_ONLY=ON \
         -DTEST_SUITE_COLLECT_STATS=ON \
         -DTEST_SUITE_USE_PERF=ON \
+        -DTEST_SUITE_RUN_BENCHMARKS=OFF \
         -C~/test-suite/cmake/caches/O3.cmake \
         ~/test-suite
 
     # Build the test-suite
-    ninja
+    ninja -j1
 
     # Run the tests with lit:
-    lit -j1 -v -o results.json . || true
+    lit -v -o results.json . || true
 }
 
 # Query version information for given day
@@ -102,7 +103,6 @@ configure_build_run
 system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head -n1)
 
 /root/test-suite/utils/compare.py \
-    --metric exec_time \
     --metric compile_time \
     --metric link_time \
     --lhs-name ${system_llvm_release} \
@@ -110,7 +110,6 @@ system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head 
     ~/system/results.json vs ~/pgo/results.json > ~/results-system-vs-pgo.txt || true
 
 /root/test-suite/utils/compare.py \
-    --metric exec_time \
     --metric compile_time \
     --metric link_time \
     --lhs-name ${system_llvm_release} \
@@ -118,7 +117,6 @@ system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head 
     ~/system/results.json vs ~/big-merge/results.json > ~/results-system-vs-big-merge.txt || true
 
 /root/test-suite/utils/compare.py \
-    --metric exec_time \
     --metric compile_time \
     --metric link_time \
     --lhs-name big-merge \

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -25,7 +25,7 @@ function configure_build_run {
 }
 
 # Query version information for given day
-yyyymmdd=20240911
+yyyymmdd=20250317
 git_rev=$(curl -sL https://github.com/fedora-llvm-team/llvm-snapshots/releases/download/snapshot-version-sync/llvm-git-revision-${yyyymmdd}.txt)
 git_rev_short="${git_rev:0:14}"
 llvm_release=$(curl -sL https://github.com/fedora-llvm-team/llvm-snapshots/releases/download/snapshot-version-sync/llvm-release-${yyyymmdd}.txt)

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -3,9 +3,6 @@
 set -x
 set -e
 
-## Source the python environment with required packages
-#source ~/mysandbox/bin/activate
-
 function configure_build_run {
     # Configure the test suite
     cmake \

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -96,7 +96,7 @@ system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head 
     --metric compile_time \
     --metric link_time \
     --lhs-name ${system_llvm_release} \
-    --rhs-name pgo-${rpm_suffix} \
+    --rhs-name pgo \
     ~/system/results.json vs ~/pgo/results.json > ~/results-system-vs-pgo.txt || true
 
 /root/test-suite/utils/compare.py \
@@ -104,15 +104,15 @@ system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head 
     --metric compile_time \
     --metric link_time \
     --lhs-name ${system_llvm_release} \
-    --rhs-name big-merge-${rpm_suffix} \
+    --rhs-name big-merge} \
     ~/system/results.json vs ~/big-merge/results.json > ~/results-system-vs-big-merge.txt || true
 
 /root/test-suite/utils/compare.py \
     --metric exec_time \
     --metric compile_time \
     --metric link_time \
-    --lhs-name big-merge-${rpm_suffix} \
-    --rhs-name pgo-${rpm_suffix} \
+    --lhs-name big-merge \
+    --rhs-name pgo \
     ~/big-merge/results.json vs ~/pgo/results.json > ~/results-big-merge-vs-pgo.txt || true
 
 bash

--- a/scripts/perf/entrypoint.sh
+++ b/scripts/perf/entrypoint.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/bash
+
+set -x
+
+# Source the python environment with required packages
+source ~/mysandbox/bin/activate
+
+function configure_build_run {
+    # Configure the test suite
+    cmake \
+        -DCMAKE_GENERATOR=Ninja \
+        -DCMAKE_C_COMPILER=/usr/bin/clang \
+        -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+        -C~/test-suite/cmake/caches/O3.cmake \
+        ~/test-suite
+
+    # Build the test-suite
+    ninja -j30
+
+    # Run the tests with lit:
+    lit -j1 -v -o results.json . || true
+}
+
+# Query version information for given day
+yyyymmdd=20240825
+git_rev=$(curl -sL https://github.com/fedora-llvm-team/llvm-snapshots/releases/download/snapshot-version-sync/llvm-git-revision-${yyyymmdd}.txt)
+git_rev_short="${git_rev:0:14}"
+llvm_release=$(curl -sL https://github.com/fedora-llvm-team/llvm-snapshots/releases/download/snapshot-version-sync/llvm-release-${yyyymmdd}.txt)
+rpm_suffix="${llvm_release}~pre${yyyymmdd}.g${git_rev_short}"
+
+echo "git_rev=$git_rev"
+echo "git_rev_short=$git_rev_short"
+echo "llvm_release=$llvm_release"
+echo "rpm_suffix=$rpm_suffix"
+
+######################################################################################
+# PGO
+######################################################################################
+
+# Install and enable the repository that provides the PGO LLVM Toolchain
+# See https://llvm.org/docs/HowToBuildWithPGO.html#building-clang-with-pgo
+dnf copr enable -y @fedora-llvm-team/llvm-snapshots-pgo-${yyyymmdd}
+dnf install -y \
+    clang-${rpm_suffix} \
+    clang-${rpm_suffix} \
+    clang-libs-${rpm_suffix} \
+    clang-resource-filesystem-${rpm_suffix} \
+    llvm-${rpm_suffix} \
+    llvm-libs-${rpm_suffix}
+
+mkdir -pv ~/pgo
+cd ~/pgo
+
+configure_build_run
+# Remove packages from that PGO repo and the repo itself
+dnf -y repository-packages copr:copr.fedorainfracloud.org:group_fedora-llvm-team:llvm-snapshots-pgo-${yyyymmdd} remove
+dnf -y copr remove @fedora-llvm-team/llvm-snapshots-pgo-${yyyymmdd}
+
+######################################################################################
+# big-merge
+######################################################################################
+
+# Install and enable the repository that provides the big-merge LLVM Toolchain
+dnf copr enable -y @fedora-llvm-team/llvm-snapshots-big-merge-${yyyymmdd}
+dnf install -y \
+    clang-${rpm_suffix} \
+    clang-${rpm_suffix} \
+    clang-libs-${rpm_suffix} \
+    clang-resource-filesystem-${rpm_suffix} \
+    llvm-${rpm_suffix} \
+    llvm-libs-${rpm_suffix}
+
+mkdir -pv ~/big-merge
+cd ~/big-merge
+
+configure_build_run
+# Remove packages from that big-merge repo and the repo itself
+dnf -y repository-packages copr:copr.fedorainfracloud.org:group_fedora-llvm-team:llvm-snapshots-big-merge-${yyyymmdd} remove
+dnf -y copr remove @fedora-llvm-team/llvm-snapshots-big-merge-${yyyymmdd}
+
+######################################################################################
+# system llvm
+######################################################################################
+
+# Build with regular clang
+dnf install -y clang clang-libs clang-resource-filesystem llvm llvm-libs
+mkdir -pv ~/system
+cd ~/system
+
+configure_build_run
+
+system_llvm_release=$(clang --version | grep -Po '[0-9]+\.[0-9]+\.[0-9]' | head -n1)
+
+/root/test-suite/utils/compare.py \
+    --metric exec_time \
+    --metric compile_time \
+    --metric link_time \
+    --lhs-name ${system_llvm_release} \
+    --rhs-name pgo-${rpm_suffix} \
+    ~/system/results.json vs ~/pgo/results.json > ~/results-system-vs-pgo.txt || true
+
+/root/test-suite/utils/compare.py \
+    --metric exec_time \
+    --metric compile_time \
+    --metric link_time \
+    --lhs-name ${system_llvm_release} \
+    --rhs-name big-merge-${rpm_suffix} \
+    ~/system/results.json vs ~/big-merge/results.json > ~/results-system-vs-big-merge.txt || true
+
+/root/test-suite/utils/compare.py \
+    --metric exec_time \
+    --metric compile_time \
+    --metric link_time \
+    --lhs-name big-merge-${rpm_suffix} \
+    --rhs-name pgo-${rpm_suffix} \
+    ~/big-merge/results.json vs ~/pgo/results.json > ~/results-big-merge-vs-pgo.txt || true
+
+bash


### PR DESCRIPTION
This container setup allows you to compare the system llvm against "big-merge" and "pgo" for the current date.

# How to

Just run `cd scripts/perf && make` to build and run the container image. It takes a long time to complete.

Then you'll be promted with a markdown output that you can copy and paste into a github issue.

The output is located between `<!--BEGIN REPORT-->` and `<!--END REPORT-->` markers.