### PR TITLE
fix for project instructions

### DIFF
--- a/project-instructions.md
+++ b/project-instructions.md
@@ -1,10 +1,14 @@
 For instructions on how to use this repository, consult the [official docs](https://docs.pagure.org/copr.copr/how_to_enable_repo.html#how-to-enable-repo).
 
-It should be enough to enable the copr repository for this project using the following command:
+We need a bit of post-configuration after enabling the copr repository for this project:
 
 ```
+$ dnf install -y jq envsubst
 $ dnf install 'dnf-command(copr)'
 $ dnf copr enable -y @fedora-llvm-team/llvm-snapshots
+$ repo_file=$(dnf repoinfo --json *llvm-snapshots* | jq -r ".[0].repo_file_path")
+$ distname=$(rpm --eval "%{?fedora:fedora}%{?rhel:rhel}") envsubst '$distname' < $repo_file > /tmp/new_repo_file
+$ cat /tmp/new_repo_file > $repo_file
 ```
 
 Then install `clang` or some of the other packages.

--- a/project-instructions.md
+++ b/project-instructions.md
@@ -3,8 +3,9 @@ For instructions on how to use this repository, consult the [official docs](http
 We need a bit of post-configuration after enabling the copr repository for this project:
 
 ```
-$ dnf install -y jq envsubst 'dnf-command(copr)'
-$ dnf copr enable -y @fedora-llvm-team/llvm-snapshots
+$ dnf -y install jq envsubst
+$ dnf -y install --skip-broken 'dnf-command(copr)' 'dnf5-command(copr)'
+$ dnf -y copr enable @fedora-llvm-team/llvm-snapshots
 $ repo_file=$(dnf repoinfo --json *llvm-snapshots* | jq -r ".[0].repo_file_path")
 $ distname=$(rpm --eval "%{?fedora:fedora}%{?rhel:rhel}") envsubst '$distname' < $repo_file > /tmp/new_repo_file
 $ cat /tmp/new_repo_file > $repo_file

--- a/project-instructions.md
+++ b/project-instructions.md
@@ -3,8 +3,7 @@ For instructions on how to use this repository, consult the [official docs](http
 We need a bit of post-configuration after enabling the copr repository for this project:
 
 ```
-$ dnf install -y jq envsubst
-$ dnf install 'dnf-command(copr)'
+$ dnf install -y jq envsubst 'dnf-command(copr)'
 $ dnf copr enable -y @fedora-llvm-team/llvm-snapshots
 $ repo_file=$(dnf repoinfo --json *llvm-snapshots* | jq -r ".[0].repo_file_path")
 $ distname=$(rpm --eval "%{?fedora:fedora}%{?rhel:rhel}") envsubst '$distname' < $repo_file > /tmp/new_repo_file


### PR DESCRIPTION
This is to avoid this warning with `dnf install clang`

```
Updating and loading repositories:
 Copr copr.fedorainfracloud.org/@fedora-llvm-team/llvm-snapshots external runtime dependency #1 - https_download_copr_fedorainfracloud_org_results_40fedora_llvm_team_llvm_compat_packages_distname_releasever_basearch                                                                                                                                                                                                                             100% | 903.0   B/s |   1.3 KiB |  00m02s
>>> Status code: 404 for https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml (IP: 2600:9000:2509:1000:4:bbc1:1840:93a1) - https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml - repomd.xml
>>> Status code: 404 for https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml (IP: 2600:9000:2509:1000:4:bbc1:1840:93a1) - https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml - repomd.xml
>>> Status code: 404 for https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml (IP: 2600:9000:2509:1000:4:bbc1:1840:93a1) - https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml - repomd.xml
>>> Status code: 404 for https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml (IP: 2600:9000:2509:1000:4:bbc1:1840:93a1) - https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/$distname-41-x86_64/repodata/repomd.xml - repomd.xml
>>> Librepo error: Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```

Obviously `$distname` isn't properly replaced without this patch.

See also https://github.com/fedora-copr/copr/issues/3387
And https://github.com/fedora-llvm-team/llvm-snapshots/pull/670 where the issue was fixed by using `dnf-3` instead of `dnf`.