### PR TITLE
Fix  copr packages not installed in Fedora 41 and newer

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -23,6 +23,11 @@ prepare:
     script: |
       dnf install -y dnf-plugins-core
       dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || true
+
+  - name: "Check that snapshot (~pre) version of LLVM is installed"
+    how: shell
+    order: 99
+    script: rpm -q --qf "%{version}" llvm-libs | grep '~pre'
 adjust:
   - discover+:
       - name: redhat-rpm-config-tests

--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -25,8 +25,11 @@ prepare:
   # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
   - how: shell
     script: |
-      dnf install -y dnf-plugins-core
-      dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || true
+      if dnf repolist | grep -q testing-farm-tag-repository; then
+        dnf install -y 'dnf5-command(config-manager)' || dnf install -y 'dnf-command(config-manager)'
+        dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || \
+          dnf config-manager setopt "testing-farm-tag-repository.priority=999"
+      fi
 
   - name: "Check that snapshot (~pre) version of LLVM is installed"
     how: shell

--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -10,13 +10,17 @@
 
 summary: LLVM Tests for snapshot gating
 prepare:
-  # dnf5's copr plugin has trouble resolving the runtime dependency repos, so
-  # we need to use dnf4. Check https://github.com/fedora-copr/copr/issues/3387
   - name: Enable copr repo
     how: shell
-    script: |
-      dnf install -y dnf-plugins-core
-      dnf-3 -y copr enable @fedora-llvm-team/$COPR_PROJECT $COPR_CHROOT
+    script:
+      - dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)'
+      - dnf -y copr enable @fedora-llvm-team/$COPR_PROJECT $COPR_CHROOT
+      # dnf5's copr plugin has trouble resolving the runtime dependency repos,
+      # and is not replacing the $distname special var. Hence we need to do that
+      # parsing ourselves.
+      # Check https://github.com/fedora-copr/copr/issues/3387
+      - sed -i "s/\$distname/$(echo "$COPR_CHROOT" | cut -d '-' -f 1)/" /etc/yum.repos.d/*$COPR_PROJECT*
+
   # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
   # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
   - how: shell


### PR DESCRIPTION
This PR fixes package installation issues in tmt runs due to dnf5 incompatibilities. Changes introduced:

* Added a check to ensure that `llvm-libs` is a snapshots package coming from copr (`~pre` version)
* Rewrite fix for dnf5 not resolving the copr runtime dependency repo. Implementation in #670 was forcing to use dnf4, while this one is dnf version agnostic.
* Improve how `testing-farm-tag-repository` priority is handled. Before trying to modify the repo we check that it exists, hence we no longer need to mask the result of commands. This now works with both dnf4 and dnf5

Tested in several environments to verify all works as expected.
* fedora-rawhide-x86_64 (dnf5, testing-farm-tag-repository): https://artifacts.dev.testing-farm.io/d698a1fa-1ab3-4ca2-b2e0-547492cefb61/
* fedora-40-x86_64 (dnf4, testing-farm-tag-repository): https://artifacts.dev.testing-farm.io/0f6e2da5-0d65-4294-a697-13a30b1fbddd/
* rhel-8-x86_64 (RedHat internal only, dnf4, no testing-farm-tag-repository) 

Fixes #671 