### PR TITLE
Enforce installing llvm-libs from the copr repo

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -20,6 +20,10 @@ prepare:
       # parsing ourselves.
       # Check https://github.com/fedora-copr/copr/issues/3387
       - sed -i "s/\$distname/$(echo "$COPR_CHROOT" | cut -d '-' -f 1)/" /etc/yum.repos.d/*$COPR_PROJECT*
+      # Ensure that latest llvm-libs (from our snapshot) is installed to prevent
+      # potential dependency solving issues when rpms depending on llvm-libs are
+      # already in the system.
+      - dnf -y install --best llvm-libs
 
   # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
   # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository


### PR DESCRIPTION
This addresses test run issues raised in #692.

Tested on [this run](https://artifacts.osci.redhat.com/testing-farm/57fd8eab-d1a5-4e65-86ba-ad8405884e92/) (RedHat internal only). 