### PR TITLE
Lower the priority of testing-farm-tag-repo as first prepare task

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -10,6 +10,17 @@
 
 summary: LLVM Tests for snapshot gating
 prepare:
+  # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
+  # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
+  - name: Set testing-farm-tag-repository priority
+    how: shell
+    script: |
+      if dnf repolist | grep -q testing-farm-tag-repository; then
+        dnf install -y 'dnf5-command(config-manager)' || dnf install -y 'dnf-command(config-manager)'
+        dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || \
+          dnf config-manager setopt "testing-farm-tag-repository.priority=999"
+      fi
+
   - name: Enable copr repo
     how: shell
     script:
@@ -24,16 +35,6 @@ prepare:
       # potential dependency solving issues when rpms depending on llvm-libs are
       # already in the system.
       - dnf -y install --best llvm-libs
-
-  # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
-  # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
-  - how: shell
-    script: |
-      if dnf repolist | grep -q testing-farm-tag-repository; then
-        dnf install -y 'dnf5-command(config-manager)' || dnf install -y 'dnf-command(config-manager)'
-        dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || \
-          dnf config-manager setopt "testing-farm-tag-repository.priority=999"
-      fi
 
   - name: "Check that snapshot (~pre) version of LLVM is installed"
     how: shell


### PR DESCRIPTION
This is a followup for #697 and fixes a corner-case we didn't noticed in that PR:

If the test system is a testing-farm system, has a testing-farm-tag-repository with high priority, and the distro has pre-installed an rpm which depends on `llvm-libs` (such as `bcc`, `mesa-dri-drivers`, etc), then `dnf install --best` will still consider as "best" the rpms coming from the highest priority repo -- which is testing-farm-tag-repository. Hence we must first lower the tag repo priority, then add the copr repo and ask dnf to install/update llvm-libs.