### PR TITLE
Add support for centos-stream-10 chroots to pgo strategy

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -48,7 +48,7 @@ jobs:
             copr_ownername: "@fedora-llvm-team"
             copr_project_tpl: "llvm-snapshots-pgo-YYYYMMDD"
             copr_monitor_tpl: "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/"
-            chroot_pattern: '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)'
+            chroot_pattern: '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-|centos-stream-10)'
             packages: "llvm"
           # - name: bootstrap
           #   maintainer_handle: "kwk"

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -23,7 +23,7 @@ jobs:
           - name: pgo
             copr_project_tpl: "@fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD"
             copr_target_project: "@fedora-llvm-team/llvm-snapshots-pgo"
-            # extra_script_file: "scripts/functions-pgo.sh"
+            extra_script_file: "scripts/functions-pgo.sh"
             clone_url_tpl: "https://src.fedoraproject.org/forks/kkleine/rpms/PKG.git"
             clone_ref: pgo
     runs-on: ubuntu-latest

--- a/scripts/functions-pgo.sh
+++ b/scripts/functions-pgo.sh
@@ -1,0 +1,6 @@
+set -x
+
+# Prints the chroots we care about.
+function get_chroots() {
+  copr list-chroots | grep -P '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-|centos-stream-10)' | sort |  tr '\n' ' '
+}

--- a/snapshot_manager/snapshot_manager/testing_farm_util.py
+++ b/snapshot_manager/snapshot_manager/testing_farm_util.py
@@ -301,6 +301,12 @@ class TestingFarmRequest:
 
         >>> TestingFarmRequest.select_ranch("fedora-rawhide-i386")
         'redhat'
+
+        >>> TestingFarmRequest.select_ranch("centos-stream-x86_64")
+        'public'
+
+        >>> TestingFarmRequest.select_ranch("centos-stream-ppc64le")
+        'redhat'
         """
         util.expect_chroot(chroot)
         ranch = None
@@ -405,6 +411,8 @@ class TestingFarmRequest:
         'RHEL-9-Nightly'
         >>> TestingFarmRequest.get_compose("rhel-8-x86_64")
         'RHEL-8-Nightly'
+        >>> TestingFarmRequest.get_compose("centos-stream-10-s390x")
+        CentOS-Stream-10
         """
         util.expect_chroot(chroot)
 

--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -229,12 +229,15 @@ def expect_chroot(chroot: str) -> str:
     >>> expect_chroot("fedora-rawhide-x86_64")
     'fedora-rawhide-x86_64'
 
+    >>> expect_chroot("centos-stream-10-x86_64")
+    'centos-stream-10-x86_64'
+
     >>> expect_chroot("fedora-rawhide-")
     Traceback (most recent call last):
       ...
     ValueError: invalid chroot fedora-rawhide-
     """
-    if not re.search(pattern=r"^[^-]+-[^-]+-[^-]+$", string=chroot):
+    if not re.search(pattern=r"^[^-]+-[^-]+-[^-]+(-[^-]+)?$", string=chroot):
         raise ValueError(f"invalid chroot {chroot}")
     return chroot
 


### PR DESCRIPTION
This adds centos-stream-10 chroots to the pgo strategy builds.