### PR TITLE
Install llvm-test-suite from copr

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -35,6 +35,8 @@ prepare:
       # potential dependency solving issues when rpms depending on llvm-libs are
       # already in the system.
       - dnf -y install --best llvm-libs
+      # Use a newer llvm-test-suite version from copr.
+      - dnf copr enable -y @fedora-llvm-team/llvm-test-suite $COPR_CHROOT
 
   - name: "Check that snapshot (~pre) version of LLVM is installed"
     how: shell


### PR DESCRIPTION
This enables the https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-test-suite/monitor/ copr repo, so use a newer llvm-test-suite in the tmt tests.