### PR TITLE
Adjust all chroots with `--with=snapshot_build`

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -130,13 +130,14 @@ jobs:
             --module-hotfixes on \
             $chroot_opts "${{ env.project_today }}"
 
-      - name: "Enable swig:4.0 module in RHEL 8 build chroots (if any)"
+      - name: "Enable snapshot_build build condition for all and swig:4.0 module in RHEL 8 build chroots (if any)"
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
           [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           for chroot in ${{ env.chroots }}; do
+            copr edit-chroot --rpmbuild-with "snapshot_build" ${{ env.project_today }}/$chroot
             if [[ "$chroot" == rhel-8-* ]]; then
               copr edit-chroot --modules "swig:4.0" ${{ env.project_today }}/$chroot
             fi


### PR DESCRIPTION
In order to avoid Copr specific code like the following in the `llvm.spec` file we have to manually specify the `--with=snapshot_build` for each chroot.

```spec
%global copr_snapshot_build_detected %(/bin/bash -fc 'if [[ "%{?copr_username}/%{?copr_projectname}" == @fedora-llvm-team/llvm-snapshots-* ]];
then
  echo "yes"
else
  echo "no"
fi')

%if "%{copr_snapshot_build_detected}" == "yes"
%bcond_without snapshot_build
%else
%bcond_with snapshot_build
%endif
```

This first began here: https://src.fedoraproject.org/rpms/llvm/pull-request/301#comment-221782