### PR TITLE
Use correct edit-chroot option

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -145,7 +145,7 @@ jobs:
             #            https://bugzilla.redhat.com/show_bug.cgi?id=2331339
             #            Once that package is accepted in Fedora, remove the following chroot edit.
             if [[ "$chroot" =~ fedora-(4[0-9]|rawhide) ]]; then
-              copr edit-chroot --repo "https://download.copr.fedorainfracloud.org/results/kkleine/python-nanobind/\$distname-\$releasever-\$basearch" ${{ env.project_today }}/$chroot
+              copr edit-chroot --repos "https://download.copr.fedorainfracloud.org/results/kkleine/python-nanobind/\$distname-\$releasever-\$basearch" ${{ env.project_today }}/$chroot
             fi
           done
 

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -145,7 +145,7 @@ jobs:
             #            https://bugzilla.redhat.com/show_bug.cgi?id=2331339
             #            Once that package is accepted in Fedora, remove the following chroot edit.
             if [[ "$chroot" =~ fedora-(4[0-9]|rawhide) ]]; then
-              copr edit-chroot --repos "https://download.copr.fedorainfracloud.org/results/kkleine/python-nanobind/\$distname-\$releasever-\$basearch" ${{ env.project_today }}/$chroot
+              copr edit-chroot --repos "copr://kkleine/python-nanobind" ${{ env.project_today }}/$chroot
             fi
           done
 


### PR DESCRIPTION
According to `copr edit-chroot --help`, the name of the option is `--repos`, not `--repo`.