### PR TITLE
Consolitate matrix configuration

### DIFF
--- a/.github/actions/generate-matrix/action.yml
+++ b/.github/actions/generate-matrix/action.yml
@@ -1,0 +1,73 @@
+# See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action#creating-an-action-metadata-file
+
+name: "Generate Matrix"
+description: "Creates a dynamic matrix for all build configurations that we have."
+inputs:
+  strategy: # "big-merge" or "pgo"
+    description: 'build strategy'
+    default: "all"
+  lookback_days:
+    description: "A JSON list of integers for how many days to look back. \"[0]\" means just today."
+    default: "[0]"
+outputs:
+  matrix:
+    description: "The build matrix to use in consequential jobs"
+    value: ${{ steps.set-matrix.outputs.myoutput }}
+runs:
+  using: "composite"
+  steps:
+    - id: set-matrix
+      shell: bash
+      run: |
+        # TODO(kwk): The JSON structures have some redundancy that we can try to
+        # avoid in a followup PR.
+
+        BIG_MERGE_CONFIG=$(jq -c <<EOF
+          {
+              "name": "big-merge",
+              "copr_project_tpl": "@fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD",
+              "copr_target_project": "@fedora-llvm-team/llvm-snapshots",
+              "clone_url_tpl": "https://src.fedoraproject.org/rpms/PKG.git",
+              "clone_ref": "rawhide",
+              "maintainer_handle": "nikic",
+              "copr_ownername": "@fedora-llvm-team",
+              "copr_project_tpl": "llvm-snapshots-big-merge-YYYYMMDD",
+              "copr_monitor_tpl": "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD/monitor/",
+              "chroot_pattern": "^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
+              "packages": "llvm"
+          }
+        EOF
+        )
+
+        PGO_CONFIG=$(jq -c <<EOF
+          {
+            "name": "pgo",
+            "copr_project_tpl": "@fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD",
+            "copr_target_project": "@fedora-llvm-team/llvm-snapshots-pgo",
+            "extra_script_file": "scripts/functions-pgo.sh",
+            "clone_url_tpl": "https://src.fedoraproject.org/forks/kkleine/rpms/PKG.git",
+            "clone_ref": "pgo",
+            "maintainer_handle": "kwk",
+            "copr_ownername": "@fedora-llvm-team",
+            "copr_project_tpl": "llvm-snapshots-pgo-YYYYMMDD",
+            "copr_monitor_tpl": "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
+            "chroot_pattern": "^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-|centos-stream-10)",
+            "packages": "llvm"
+          }
+        EOF
+        )
+
+        if [[ '${{ inputs.strategy }}' == 'big-merge' ]]; then
+          INCLUDES="[$BIG_MERGE_CONFIG]"
+          NAMES='["big-merge"]'
+        elif [[ '${{ inputs.strategy }}' == 'pgo' ]]; then
+          INCLUDES="[$PGO_CONFIG]"
+          NAMES='["pgo"]'
+        else
+          INCLUDES="[$BIG_MERGE_CONFIG, $PGO_CONFIG]"
+          NAMES='["big-merge", "pgo"]'
+        fi
+
+        LOOKBACK_DAYS="${{ inputs.lookback_days }}"
+
+        echo "myoutput=$(jq -cn --argjson includes "$INCLUDES" --argjson names "$NAMES" --argjson lookback_days "$LOOKBACK_DAYS" '{name: $names, today_minus_n_days: $lookback_days, include:$includes}')" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -14,51 +14,36 @@ on:
         required: true
         type: string
       strategy:
-        description: 'strategy (e.g. standalone, big-merge)'
-        required: true
-        type: string
+          description: 'build strategy'
+          required: true
+          type: choice
+          default: all
+          options:
+          - all
+          - big-merge
+          - pgo
 
 permissions:
   # We need this in order to create or update snapshot issues
   issues: write
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      mymatrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/generate-matrix
+      id: set-matrix
+      with:
+        strategy: ${{ inputs.strategy }}
+        lookback_days: "[0,1,2]"
   check-snapshot:
+    needs: generate-matrix
     strategy:
       fail-fast: false
-      matrix:
-        today_minus_n_days: [0, 1, 2]
-        name: [big-merge, pgo]
-        include:
-          # - name: standalone
-          #   maintainer_handle: "tbaederr"
-          #   copr_ownername: "@fedora-llvm-team"
-          #   copr_project_tpl: "llvm-snapshots-incubator-YYYYMMDD"
-          #   copr_monitor_tpl: "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-incubator-YYYYMMDD/monitor/"
-          #   packages: "python-lit llvm clang lld compiler-rt libomp"
-          - name: big-merge
-            maintainer_handle: "nikic"
-            copr_ownername: "@fedora-llvm-team"
-            copr_project_tpl: "llvm-snapshots-big-merge-YYYYMMDD"
-            copr_monitor_tpl: "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD/monitor/"
-            chroot_pattern: '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)'
-            packages: "llvm"
-          - name: pgo
-            maintainer_handle: "kwk"
-            copr_ownername: "@fedora-llvm-team"
-            copr_project_tpl: "llvm-snapshots-pgo-YYYYMMDD"
-            copr_monitor_tpl: "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/"
-            chroot_pattern: '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-|centos-stream-10)'
-            packages: "llvm"
-          # - name: bootstrap
-          #   maintainer_handle: "kwk"
-          #   copr_ownername: "@fedora-llvm-team"
-          #   copr_project_tpl: "llvm-snapshots-bootstrap-YYYYMMDD"
-          #   copr_monitor_tpl: "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-bootstrap-YYYYMMDD/monitor/"
-          #   chroot_pattern: 'fedora-39-x86_64'
-          #   packages: "llvm"
-
-
+      matrix: ${{fromJson(needs.generate-matrix.outputs.mymatrix)}}
     runs-on: ubuntu-latest
     steps:
       - name: Setup Copr config file

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -12,7 +12,9 @@ on:
         description: 'build strategy'
         required: true
         type: choice
+        default: all
         options:
+        - all
         - big-merge
         - pgo
 
@@ -20,41 +22,13 @@ jobs:
   generate-matrix:
     runs-on: ubuntu-latest
     outputs:
-      mymatrix: ${{ steps.set-matrix.outputs.myoutput }}
+      mymatrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - id: set-matrix
-      run: |
-        BIG_MERGE_CONFIG=$(jq -c <<EOF
-          {
-              "name": "big-merge",
-              "copr_project_tpl": "@fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD",
-              "copr_target_project": "@fedora-llvm-team/llvm-snapshots",
-              "clone_url_tpl": "https://src.fedoraproject.org/rpms/PKG.git",
-              "clone_ref": "rawhide"
-          }
-        EOF
-        )
-
-        PGO_CONFIG=$(jq -c <<EOF
-          {
-            "name": "pgo",
-            "copr_project_tpl": "@fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD",
-            "copr_target_project": "@fedora-llvm-team/llvm-snapshots-pgo",
-            "extra_script_file": "scripts/functions-pgo.sh",
-            "clone_url_tpl": "https://src.fedoraproject.org/forks/kkleine/rpms/PKG.git",
-            "clone_ref": "pgo"
-          }
-        EOF
-        )
-
-        if [[ '${{ inputs.strategy }}' == 'big-merge' ]]; then
-          INCLUDES="[$BIG_MERGE_CONFIG]"
-        elif [[ '${{ inputs.strategy }}' == 'pgo' ]]; then
-          INCLUDES="[$PGO_CONFIG]"
-        else
-          INCLUDES="[$BIG_MERGE_CONFIG, $PGO_CONFIG]"
-        fi
-        echo "myoutput=$(jq -cn --argjson includes "$INCLUDES" '{include:$includes}')" >> $GITHUB_OUTPUT
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/generate-matrix
+      id: set-matrix
+      with:
+        strategy: ${{ inputs.strategy }}
 
   build-on-copr:
     needs: generate-matrix

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.mymatrix)}}
     runs-on: ubuntu-latest
-    container: fedora:39
+    container: fedora:41
     steps:
       - name: Setup Copr config file
         env:


### PR DESCRIPTION
I've created an action that lets us re-use a dynamic matrix configuration for both, building on copr and running checks.

The matrix from both touched workflows were simply merged and there is still some deduplication work ahead. But at least they share a common place now and one can ask for a matrix using workflow_dispatch events now.

Also, some of the low-hanging-fruit optimizations like `inputs.strategy == matrix.name` removal in `check-snapshots.yml` are not done to keep this PR reviewable.