### PR TITLE
Only run build and check workflows on org github repo

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -33,6 +33,7 @@ permissions:
 
 jobs:
   generate-matrix:
+    if: github.repository_owner == 'fedora-llvm-team'
     runs-on: ubuntu-latest
     outputs:
       mymatrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -44,6 +45,7 @@ jobs:
         strategy: ${{ inputs.strategy }}
         lookback_days: ${{ inputs.lookback_days }}
   check-snapshot:
+    if: github.repository_owner == 'fedora-llvm-team'
     needs: generate-matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   generate-matrix:
+    if: github.repository_owner == 'fedora-llvm-team'
     runs-on: ubuntu-latest
     outputs:
       mymatrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -32,6 +33,7 @@ jobs:
         lookback_days: "[0]"
 
   build-on-copr:
+    if: github.repository_owner == 'fedora-llvm-team'
     needs: generate-matrix
     strategy:
       fail-fast: false


### PR DESCRIPTION
We've identified people modifying the our org's copr repo by accident. This ensures for NEW forks, that this won't happen again by accident. Existing forks need to be adapted manually to avoid this modification.