### PR TITLE
Install python3-nanobind-devel without copr

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -153,12 +153,6 @@ jobs:
             if [[ "$chroot" == rhel-8-* ]]; then
               copr edit-chroot --modules "swig:4.0" ${{ env.project_today }}/$chroot
             fi
-            # TODO(kwk): The python-nanobind package acceptance review is taking place here:
-            #            https://bugzilla.redhat.com/show_bug.cgi?id=2331339
-            #            Once that package is accepted in Fedora, remove the following chroot edit.
-            if [[ "$chroot" =~ fedora-(4[0-9]|rawhide) ]]; then
-              copr edit-chroot --repos "copr://kkleine/python-nanobind" ${{ env.project_today }}/$chroot
-            fi
 
             # Dump chroot information after all modification
             copr get-chroot ${{ env.project_today }}/$chroot


### PR DESCRIPTION
We now have an official Fedora package for `python-nanobind`: https://src.fedoraproject.org/rpms/python-nanobind.

Bodhi updates:

* rawhide: https://bodhi.fedoraproject.org/updates/FEDORA-2024-8da0476884
* f41: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57e0e550fb

This effectively reverts 917b76cca330ce8806a26dd7c85f559036207722 and 534975cfaaa54dd85bbf6ab64172874088b6218f.