### PR TITLE
Revert "Install python3-nanobind-devel without copr"

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -156,7 +156,7 @@ jobs:
             # TODO(kwk): The python-nanobind package acceptance review is taking place here:
             #            https://bugzilla.redhat.com/show_bug.cgi?id=2331339
             #            Once that package is accepted in Fedora, remove the following chroot edit.
-            if [[ "$chroot" =~ fedora-(4[1-9]|rawhide) ]]; then
+            if [[ "$chroot" =~ fedora-(4[1-9]) ]]; then
               copr edit-chroot --repos "copr://kkleine/python-nanobind" ${{ env.project_today }}/$chroot
             fi
 

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -156,7 +156,7 @@ jobs:
             # TODO(kwk): The python-nanobind package acceptance review is taking place here:
             #            https://bugzilla.redhat.com/show_bug.cgi?id=2331339
             #            Once that package is accepted in Fedora, remove the following chroot edit.
-            if [[ "$chroot" =~ fedora-(4[0-9]|rawhide) ]]; then
+            if [[ "$chroot" =~ fedora-(4[1-9]|rawhide) ]]; then
               copr edit-chroot --repos "copr://kkleine/python-nanobind" ${{ env.project_today }}/$chroot
             fi
 

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -153,6 +153,12 @@ jobs:
             if [[ "$chroot" == rhel-8-* ]]; then
               copr edit-chroot --modules "swig:4.0" ${{ env.project_today }}/$chroot
             fi
+            # TODO(kwk): The python-nanobind package acceptance review is taking place here:
+            #            https://bugzilla.redhat.com/show_bug.cgi?id=2331339
+            #            Once that package is accepted in Fedora, remove the following chroot edit.
+            if [[ "$chroot" =~ fedora-(4[0-9]|rawhide) ]]; then
+              copr edit-chroot --repos "copr://kkleine/python-nanobind" ${{ env.project_today }}/$chroot
+            fi
 
             # Dump chroot information after all modification
             copr get-chroot ${{ env.project_today }}/$chroot


### PR DESCRIPTION
Temporarily revert commit be591b596d213d4020b0deef97e6385ba212fc6f while we wait for python-nanobind to reach stable in all supported Fedora versions.