### PR TITLE
mass-rebuild-reporter: Only search for issues in the current repsitory

### DIFF
--- a/.github/workflows/mass-rebuild-reporter.yml
+++ b/.github/workflows/mass-rebuild-reporter.yml
@@ -34,7 +34,7 @@ jobs:
           result-encoding: string
           script: |
             const issues = await github.rest.search.issuesAndPullRequests({
-              q: "label:mass-rebuild+is:issue",
+              q: "repo:" + process.env.GITHUB_REPOSITORY + "+label:mass-rebuild+is:issue",
               sort: "created",
               order: "desc",
               per_page: 1


### PR DESCRIPTION
When looking for the previous issue filed for a mass rebuild, we were searching through repositories in all of GitHub instead of just fedora-llvm-team/llvm-snapshots.  This meant that issues filed in forks would prevent the mass rebuild reporter from filing and issue in the main repository.