### PR TITLE
[rebuilder] Fix doctest

### DIFF
--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -209,7 +209,7 @@ def get_monthly_rebuild_regressions(
     >>> project_name = "fedora41-clang-20"
     >>> regressions = get_monthly_rebuild_regressions(project_owner, project_name, datetime.datetime.fromisoformat("2024-11-11"), copr_pkgs)
     >>> print(regressions)
-    [{'name': 'f', 'url': 'https://copr.fedorainfracloud.org/coprs/@fedora-llvm-team/fedora41-clang-20/build/2/'}]
+    [{'name': 'f', 'url': 'https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/fedora41-clang-20/build/2/'}]
 
     """
     pkgs = []


### PR DESCRIPTION
Fix this test:

```
_____________ [doctest] rebuilder.get_monthly_rebuild_regressions ______________
202     >>> b = {"name" : "b", "builds" : { "latest" : { "id" : 1, "state" : "succeeded", "submitted_on" : 1731457321 } , "latest_succeeded" : None } }
203     >>> c = {"name" : "c", "builds" : { "latest" : { "id" : 1, "state" : "succeeded", "submitted_on" : 1731457321 } , "latest_succeeded" : { "id" : 1 } } }
204     >>> d = {"name" : "d", "builds" : { "latest" : { "id" : 2, "state" : "canceled", "submitted_on" : 1731457321 } , "latest_succeeded" : { "id" : 1 } } }
205     >>> e = {"name" : "e", "builds" : { "latest" : { "id" : 2, "state" : "failed", "submitted_on" : 1 } , "latest_succeeded" : { "id" : 1 } } }
206     >>> f = {"name" : "f", "builds" : { "latest" : { "id" : 2, "state" : "failed", "submitted_on" : 1731457321 } , "latest_succeeded" : { "id" : 1 } } }
207     >>> copr_pkgs= [CoprPkg(p) for p in [ a, b, c, d, e, f ]]
208     >>> project_owner = "@fedora-llvm-team"
209     >>> project_name = "fedora41-clang-20"
210     >>> regressions = get_monthly_rebuild_regressions(project_owner, project_name, datetime.datetime.fromisoformat("2024-11-11"), copr_pkgs)
211     >>> print(regressions)
Expected:
    [{'name': 'f', 'url': 'https://copr.fedorainfracloud.org/coprs/@fedora-llvm-team/fedora41-clang-20/build/2/'}]
Got:
    [{'name': 'f', 'url': 'https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/fedora41-clang-20/build/2/'}]
```

Notice the `@` and `g/` in the expected and actual output.