### PR TITLE
Skip tests that require access to the token

### DIFF
--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -38,6 +38,10 @@ class Reaction(enum.StrEnum):
     EYES = "EYES"  # Represents the :eyes: emoji.
 
 
+class MissingToken(Exception):
+    """Could not retrieve a Github token."""
+
+
 class GithubClient:
     dirname = pathlib.Path(os.path.dirname(__file__))
 
@@ -52,6 +56,10 @@ class GithubClient:
                 f"Reading Github token from this environment variable: {self.config.github_token_env}"
             )
             github_token = os.getenv(self.config.github_token_env)
+        if github_token is None or len(github_token) == 0:
+            # We can't proceed without a Github token, otherwise we'll trigger
+            # an assertion failure.
+            raise MissingToken("Could not retrieve the token")
         auth = github.Auth.Token(github_token)
         self.github = github.Github(auth=auth)
         self.gql = github_graphql.GithubGraphQL(token=github_token, raise_on_error=True)

--- a/snapshot_manager/tests/github_util_test.py
+++ b/snapshot_manager/tests/github_util_test.py
@@ -48,7 +48,13 @@ class TestGithub(base_test.TestBase):
         cfg = self.config
         cfg.datetime = datetime.datetime(year=2024, month=2, day=27)
         self.assertEqual("20240227", cfg.yyyymmdd)
-        gh = github_util.GithubClient(config=cfg)
+
+        try:
+            gh = github_util.GithubClient(config=cfg)
+        except github_util.MissingToken:
+            pytest.skip(
+                "Skip test because this execution doesn't have access to a Github token"
+            )
 
         issue = gh.get_todays_github_issue(
             strategy="big-merge", github_repo="fedora-llvm-team/llvm-snapshots"
@@ -104,7 +110,13 @@ class TestGithub(base_test.TestBase):
         pass
 
     def test_get_workflow(self):
-        gh = github_util.GithubClient(config=self.config)
+        try:
+            gh = github_util.GithubClient(config=self.config)
+        except github_util.MissingToken:
+            pytest.skip(
+                "Skip test because this execution doesn't have access to a Github token"
+            )
+
         repo = gh.github.get_repo("fedora-llvm-team/llvm-snapshots")
         workflow = repo.get_workflow("check-snapshots.yml")
         self.assertIsNotNone(workflow)

--- a/snapshot_manager/tests/testing_farm_util_test.py
+++ b/snapshot_manager/tests/testing_farm_util_test.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+import pytest
 import tests.base_test as base_test
 
 import snapshot_manager.github_util as github_util
@@ -13,7 +14,13 @@ class TestTestingFarmUtil(base_test.TestBase):
         cfg = self.config
         cfg.datetime = datetime.datetime(year=2024, month=2, day=27)
         self.assertEqual("20240227", cfg.yyyymmdd)
-        gh = github_util.GithubClient(config=cfg)
+
+        try:
+            gh = github_util.GithubClient(config=cfg)
+        except github_util.MissingToken:
+            pytest.skip(
+                "Skip test because this execution doesn't have access to a Github token"
+            )
 
         issue = gh.get_todays_github_issue(
             strategy="big-merge", github_repo="fedora-llvm-team/llvm-snapshots"


### PR DESCRIPTION
Add function to GithubClient.has_token() and use it in order to skip tests that require access to a Github token.
This will allow to run a smaller set of tests from other forks and, most importantly, won't block their merge.