### PR TITLE
Introduce github action linting in pre-commit

### DIFF
--- a/.github/workflows/build-reproducer-container.yml
+++ b/.github/workflows/build-reproducer-container.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y install podman
-          podman build -t ghcr.io/$GITHUB_REPOSITORY_OWNER/llvm-snapshots-reproducer -f Containerfile.mass-rebuild scripts/
-          podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
-          podman push ghcr.io/$GITHUB_REPOSITORY_OWNER/llvm-snapshots-reproducer
+          podman build -t "ghcr.io/$GITHUB_REPOSITORY_OWNER/llvm-snapshots-reproducer" -f Containerfile.mass-rebuild scripts/
+          podman login -u ${{ github.actor }} -p "$GITHUB_TOKEN" ghcr.io
+          podman push "ghcr.io/$GITHUB_REPOSITORY_OWNER/llvm-snapshots-reproducer"

--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -60,7 +60,7 @@ jobs:
           COPR_CONFIG_FILE: ${{ secrets.COPR_CONFIG }}
         run: |
           mkdir -p ~/.config
-          printf "$COPR_CONFIG_FILE" > ~/.config/copr
+          echo "$COPR_CONFIG_FILE" > ~/.config/copr
 
       - name: Install Copr CLI
         if: github.event_name != 'workflow_dispatch' || (matrix.today_minus_n_days == 0 && inputs.strategy == matrix.name)
@@ -83,24 +83,24 @@ jobs:
         run: |
           extra_args=""
 
-          if [[ ! -z "${{ matrix.chroot_pattern }}" ]]; then
+          if [[ -n "${{ matrix.chroot_pattern }}" ]]; then
             extra_args="${extra_args} --chroot-pattern ${{matrix.chroot_pattern}}"
           fi
 
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             yyyymmdd=${{inputs.yyyymmdd}}
           else
-            yyyymmdd=`date --date='${{matrix.today_minus_n_days}} days ago' +%Y%m%d`
+            yyyymmdd=$(date --date='${{matrix.today_minus_n_days}} days ago' +%Y%m%d)
           fi
 
           python3 snapshot_manager/main.py \
-            --github-repo ${GITHUB_REPOSITORY} \
+            --github-repo "${GITHUB_REPOSITORY}" \
             --github-token-env GITHUB_TOKEN \
-            check ${extra_args}\
+            check "${extra_args}"\
             --maintainer-handle ${{matrix.maintainer_handle}} \
             --packages ${{matrix.packages}} \
             --build-strategy ${{matrix.name}} \
             --copr-ownername ${{matrix.copr_ownername}} \
             --copr-project-tpl ${{matrix.copr_project_tpl}} \
             --copr-monitor-tpl ${{matrix.copr_monitor_tpl}} \
-            --yyyymmdd $yyyymmdd
+            --yyyymmdd "$yyyymmdd"

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -48,7 +48,7 @@ jobs:
           COPR_CONFIG_FILE: ${{ secrets.COPR_CONFIG }}
         run: |
           mkdir -p ~/.config
-          printf "$COPR_CONFIG_FILE" > ~/.config/copr
+          echo "$COPR_CONFIG_FILE" > ~/.config/copr
 
       - name: Install Copr CLI and required tools
         run: |
@@ -60,57 +60,61 @@ jobs:
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
-          today=`date +%Y%m%d`
-          yesterday=`date -d "${today} -1 day" +%Y%m%d`
+          today=$(date +%Y%m%d)
+          yesterday=$(date -d "${today} -1 day" +%Y%m%d)
 
-          packages="`get_packages`"
-          chroots="`get_chroots`"
+          packages="$(get_packages)"
+          chroots="$(get_chroots)"
 
           username=@fedora-llvm-team
-          echo "username=$username" >> $GITHUB_ENV
-          echo "packages=$packages" >> $GITHUB_ENV
-          echo "chroots=$chroots" >> $GITHUB_ENV
-          echo "all_chroots=$all_chroots" >> $GITHUB_ENV
-          echo "project_today=${{ matrix.copr_ownername }}/${{ matrix.copr_project_tpl }}" | sed "s/YYYYMMDD/$today/" >> $GITHUB_ENV
-          echo "project_yesterday=${{ matrix.copr_ownername }}/${{ matrix.copr_project_tpl }}" | sed "s/YYYYMMDD/$yesterday/" >> $GITHUB_ENV
-          echo "project_target=${{ matrix.copr_target_project }}" >> $GITHUB_ENV
+          {
+            echo "username=$username"
+            echo "packages=$packages"
+            echo "chroots=$chroots"
+            echo "all_chroots=$all_chroots"
+            echo "project_today=${{ matrix.copr_ownername }}/${{ matrix.copr_project_tpl }}" | sed "s/YYYYMMDD/$today/"
+            echo "project_yesterday=${{ matrix.copr_ownername }}/${{ matrix.copr_project_tpl }}" | sed "s/YYYYMMDD/$yesterday/"
+            echo "project_target=${{ matrix.copr_target_project }}"
+          } >> "$GITHUB_ENV"
 
       - name: "Check for Copr projects existence (yesterday, today, target)"
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           # Check if yesterday's project exists and all builds succeeded
-          yesterdays_project_exists=`project_exists ${{ env.project_yesterday }}`
+          yesterdays_project_exists=$(project_exists ${{ env.project_yesterday }})
           if [[ "$yesterdays_project_exists" == "true" ]]; then
             if ! has_all_good_builds ${{env.project_yesterday}}; then
               yesterdays_project_exists=false
             fi
           fi
 
-          echo "todays_project_exists=`project_exists ${{ env.project_today }}`" >> $GITHUB_ENV
-          echo "yesterdays_project_exists=$yesterdays_project_exists" >> $GITHUB_ENV
-          echo "target_project_exists=`project_exists ${{ env.project_target }}`" >> $GITHUB_ENV
+          {
+            echo "todays_project_exists=$(project_exists ${{ env.project_today }})"
+            echo "yesterdays_project_exists=$yesterdays_project_exists"
+            echo "target_project_exists=$(project_exists ${{ env.project_target }})"
+          } >> "$GITHUB_ENV"
 
       - name: "Canceling active builds (if any) in today's Copr project before recreating it: ${{ env.project_today }}"
         if: ${{ env.todays_project_exists == 'true' }}
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           build_ids=""
-          for build_id in `get_active_build_ids ${{ env.project_today }}`; do
+          for build_id in $(get_active_build_ids ${{ env.project_today }}); do
             echo "Canceling build with ID $build_id"
-            copr cancel $build_id
+            copr cancel "$build_id"
             build_ids="$build_ids $build_id"
           done
           if [[ "$build_ids" != "" ]]; then
             echo "Waiting for build IDs to be canceled: $build_ids"
-            copr watch-build $build_ids || true
+            copr watch-build "$build_ids" || true
           fi
 
       - name: "Deleting today's Copr project before recreating it: ${{ env.project_today }}"
@@ -118,7 +122,7 @@ jobs:
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           copr delete ${{ env.project_today }}
 
@@ -126,13 +130,13 @@ jobs:
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
-          chroot_opts=`for c in ${{ env.chroots }}; do echo -n " --chroot $c "; done`
+          chroot_opts=$(for c in ${{ env.chroots }}; do echo -n " --chroot $c "; done)
 
           copr create \
-            --instructions "`cat project-instructions.md`" \
-            --description  "`cat project-description.md`" \
+            --instructions "$(cat project-instructions.md)" \
+            --description  "$(cat project-description.md)" \
             --unlisted-on-hp on \
             --enable-net on \
             --runtime-repo-dependency "https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/\$distname-\$releasever-\$basearch" \
@@ -140,39 +144,39 @@ jobs:
             --appstream off \
             --delete-after-days 32 \
             --module-hotfixes on \
-            $chroot_opts "${{ env.project_today }}"
+            "$chroot_opts" "${{ env.project_today }}"
 
       - name: "Enable snapshot_build build condition for all and swig:4.0 module in RHEL 8 build chroots (if any)"
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           for chroot in ${{ env.chroots }}; do
-            copr edit-chroot --rpmbuild-with "snapshot_build" ${{ env.project_today }}/$chroot
+            copr edit-chroot --rpmbuild-with "snapshot_build" "${{ env.project_today }}/$chroot"
             if [[ "$chroot" == rhel-8-* ]]; then
-              copr edit-chroot --modules "swig:4.0" ${{ env.project_today }}/$chroot
+              copr edit-chroot --modules "swig:4.0" "${{ env.project_today }}/$chroot"
             fi
 
             # Dump chroot information after all modification
-            copr get-chroot ${{ env.project_today }}/$chroot
+            copr get-chroot "${{ env.project_today }}/$chroot"
           done
 
       - name: "Create today's packages: ${{ env.packages }}"
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           for pkg in ${{ env.packages }}; do
-            clone_url=`echo "${{ matrix.clone_url_tpl }}" | sed "s/PKG/$pkg/"`
+            clone_url=$(echo "${{ matrix.clone_url_tpl }}" | sed "s/PKG/$pkg/")
             copr add-package-scm \
-              --clone-url ${clone_url} \
+              --clone-url "${clone_url}" \
               --commit ${{ matrix.clone_ref }} \
-              --spec ${pkg}.spec \
+              --spec "${pkg}.spec" \
               --type git \
               --method make_srpm \
-              --name ${pkg} \
+              --name "${pkg}" \
               "${{ env.project_today }}"
           done
 
@@ -180,7 +184,7 @@ jobs:
         shell: bash -e {0}
         run: |
           source scripts/functions.sh
-          [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
+          [[ -n "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
           for chroot in ${{ env.chroots }}; do
             # Start a new batch
@@ -192,12 +196,12 @@ jobs:
                 copr build-package \
                   --timeout $((30*3600)) \
                   --nowait \
-                  --name $pkg ${after_build_id} \
-                  --chroot ${chroot} \
+                  --name "$pkg" "${after_build_id}" \
+                  --chroot "${chroot}" \
                   ${{ env.project_today }} \
-                  | tee ${pkg}.log
+                  | tee "${pkg}.log"
 
-                after_build_id="--after-build-id `cat ${pkg}.log | grep -Po 'Created builds: \K(\d+)'`"
+                after_build_id="--after-build-id $(grep -Po 'Created builds: \K(\d+)' "${pkg}.log")"
               fi
             done
           done

--- a/.github/workflows/mass-rebuild-reporter.yml
+++ b/.github/workflows/mass-rebuild-reporter.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           sudo dnf install -y python3-dnf python3-copr
           if python3 scripts/rebuilder.py rebuild-in-progress; then
-            echo "completed=false" >> $GITHUB_OUTPUT
+            echo "completed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -61,10 +61,10 @@ jobs:
 
           echo "last_rebuild: $last_rebuild current_snapshot: $current_snapshot"
 
-          if [ $last_rebuild -gt $current_snapshot ]; then
-            echo "completed=false" >> $GITHUB_OUTPUT
+          if [ "$last_rebuild" -gt "$current_snapshot" ]; then
+            echo "completed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "completed=true" >> $GITHUB_OUTPUT
+            echo "completed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Collect Regressions
@@ -72,7 +72,7 @@ jobs:
         id: regressions
         run: |
           python3 scripts/rebuilder.py get-regressions --start-date ${{ steps.last-report.outputs.result }} > regressions
-          echo "REGRESSIONS=$(cat regressions)" >> $GITHUB_OUTPUT
+          echo "REGRESSIONS=$(cat regressions)" >> "$GITHUB_OUTPUT"
 
       - name: Create Report
         if: steps.new-rebuild.outputs.completed == 'true'

--- a/.github/workflows/mass-rebuild-runner.yml
+++ b/.github/workflows/mass-rebuild-runner.yml
@@ -29,7 +29,7 @@ jobs:
           COPR_CONFIG_FILE: ${{ secrets.COPR_CONFIG }}
         run: |
           mkdir -p ~/.config
-          printf "$COPR_CONFIG_FILE" > ~/.config/copr
+          echo "$COPR_CONFIG_FILE" > ~/.config/copr
 
       - name: Start rebuild
         run: |

--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -68,9 +68,11 @@ jobs:
     steps:
       - name: Get Chroots
         id: chroots-step
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          echo "${{ github.event.comment.body }}" | grep -Pe '^\s*/retest\s+'
-          chroots=$(echo "${{ github.event.comment.body }}" | sed 's/^\s*\/retest\s*//g')
+          echo "$COMMENT_BODY" | grep -Pe '^\s*/retest\s+'
+          chroots=$(echo "$COMMENT_BODY" | sed 's/^\s*\/retest\s*//g')
           echo "chroots=$chroots" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-python
@@ -81,7 +83,7 @@ jobs:
           chroots: ${{ env.chroots }}
         run: |
           python3 snapshot_manager/main.py \
-            --github-repo ${GITHUB_REPOSITORY} \
+            --github-repo "${GITHUB_REPOSITORY}" \
             --github-token-env GITHUB_TOKEN \
             retest \
             --trigger-comment-id ${{ github.event.comment.id }} \

--- a/.github/workflows/sync-on-llvm-version.yml
+++ b/.github/workflows/sync-on-llvm-version.yml
@@ -71,33 +71,32 @@ jobs:
           else
             echo "commit_hash doesn't look like a SHA1 (maybe it is a branch or tag name). Trying to resolve it: ${commit_hash}"
             # See https://docs.github.com/de/rest/commits/commits?apiVersion=2022-11-28#list-branches-for-head-commit
-            commit_hash=`curl -L \
+            commit_hash=$(curl -L \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{env.GITHUB_TOKEN}}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/llvm/llvm-project/commits/${commit_hash}/branches-where-head \
-            | jq -r '.[0].commit.sha'`
+              "https://api.github.com/repos/llvm/llvm-project/commits/${commit_hash}/branches-where-head" \
+            | jq -r '.[0].commit.sha')
           fi
 
-          echo "commit_hash=${commit_hash}" >> $GITHUB_ENV
-
+          echo "commit_hash=${commit_hash}" >> "$GITHUB_ENV"
           yyyymmdd=$(date +%Y%m%d)
           versionfile=LLVMVersion.cmake
-          url=https://raw.githubusercontent.com/llvm/llvm-project/${commit_hash}/cmake/Modules/${versionfile}
+          url="https://raw.githubusercontent.com/llvm/llvm-project/${commit_hash}/cmake/Modules/${versionfile}"
           echo "Getting ${url}"
-          curl -sL -o ${versionfile} ${url}
+          curl -sL -o "${versionfile}" "${url}"
 
           echo "Version file:"
-          cat ${versionfile}
+          cat "${versionfile}"
 
-          llvm_snapshot_git_revision=${commit_hash}
-          llvm_snapshot_version=`grep -ioP 'set\(\s*LLVM_VERSION_(MAJOR|MINOR|PATCH)\s\K[0-9]+' ${versionfile} | paste -sd '.'`
+          llvm_snapshot_git_revision="${commit_hash}"
+          llvm_snapshot_version=$(grep -ioP 'set\(\s*LLVM_VERSION_(MAJOR|MINOR|PATCH)\s\K[0-9]+' "${versionfile}" | paste -sd '.')
 
-          echo "${llvm_snapshot_version}" > llvm-release-${yyyymmdd}.txt
-          echo "${llvm_snapshot_git_revision}" > llvm-git-revision-${yyyymmdd}.txt
+          echo "${llvm_snapshot_version}" > "llvm-release-${yyyymmdd}.txt"
+          echo "${llvm_snapshot_git_revision}" > "llvm-git-revision-${yyyymmdd}.txt"
 
-          echo "llvm_release=`cat llvm-release-${yyyymmdd}.txt`"
-          echo "llvm_git_revision=`cat llvm-git-revision-${yyyymmdd}.txt`"
+          echo "llvm_release=$(cat "llvm-release-${yyyymmdd}.txt")"
+          echo "llvm_git_revision=$(cat "llvm-git-revision-${yyyymmdd}.txt")"
 
           ./scripts/upload-source-snapshots.py \
             --token ${{ secrets.GITHUB_TOKEN }} \

--- a/.github/workflows/update-build-time-diagrams.yml
+++ b/.github/workflows/update-build-time-diagrams.yml
@@ -36,7 +36,7 @@ jobs:
           COPR_CONFIG_FILE: ${{ secrets.COPR_CONFIG }}
         run: |
           mkdir -p ~/.config
-          printf "$COPR_CONFIG_FILE" > ~/.config/copr
+          echo "$COPR_CONFIG_FILE" > ~/.config/copr
 
       - uses: actions/checkout@v4
         with:
@@ -64,9 +64,9 @@ jobs:
           create_diagrams: ${{ github.event_name == 'schedule' && true || github.event.inputs.create_diagrams }}
         run: |
           if ${{ env.get_stats }}; then
-            main/scripts/get-build-stats.py --copr-projectname llvm-snapshots-incubator-`date '+%Y%m%d'` | tee -a gh-pages/build-stats.csv
-            main/scripts/get-build-stats.py --copr-projectname llvm-snapshots-big-merge-`date '+%Y%m%d'` | tee -a gh-pages/build-stats-big-merge.csv
-            main/scripts/get-build-stats.py --copr-projectname llvm-snapshots-pgo-`date '+%Y%m%d'` | tee -a gh-pages/build-stats-pgo.csv
+            main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-incubator-$(date '+%Y%m%d')" | tee -a gh-pages/build-stats.csv
+            main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-big-merge-$(date '+%Y%m%d')" | tee -a gh-pages/build-stats-big-merge.csv
+            main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-pgo-$(date '+%Y%m%d')" | tee -a gh-pages/build-stats-pgo.csv
             git -C gh-pages add build-stats.csv build-stats-big-merge.csv build-stats-pgo.csv
           fi
           if ${{ env.create_diagrams }}; then
@@ -75,6 +75,7 @@ jobs:
             mv fig-*.html gh-pages/
             git -C gh-pages add index.html fig-*.html
           fi
+          # shellcheck disable=SC2078
           if [[ ${{ env.get_stats }} || ${{ env.create_diagrams }} ]]; then
             cd gh-pages
             git commit -m "Automatically update build stats"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,4 +55,10 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.12
         force-exclude: "^snapshot_manager/tests/(test_logs|testing-farm-logs)/"
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+    - id: actionlint
+
 exclude: "^(snapshot_manager/tests/(test_logs|testing-farm-logs)/|media)"


### PR DESCRIPTION
This checks github action files in pre-commit. To run this locally, make sure you have `shellcheck` installed.

`actionlint` found these kind of problems and this PR addresses them (`$ actionlint -oneline`).

1. Use `$(...)` notation instead of legacy backticks \`...\`
2. Double quote to prevent globbing and word splitting
3. Don't use variables in the `printf` format string. Use `printf '..%s..' "$foo"`
4. Use `-n` instead of `! -z`
5. Consider using `{ cmd1; cmd2; } >> file` instead of individual redirects
6. `"github.event.comment.body"` is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable. see https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions for more details
7. This expression is constant. Did you forget a `$` somewhere? - I have ignored that one because I think it was a false report. Wasn't it? 

Here's a detailed list of all the problems that actionlint found:

```
.github/workflows/build-reproducer-container.yml:22:9: shellcheck reported issue in this script: SC2086:info:3:25: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/build-reproducer-container.yml:22:9: shellcheck reported issue in this script: SC2086:info:4:40: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/build-reproducer-container.yml:22:9: shellcheck reported issue in this script: SC2086:info:5:21: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/check-snapshots.yml:61:9: shellcheck reported issue in this script: SC2059:info:2:8: Don't use variables in the printf format string. Use printf '..%s..' "$foo" [shellcheck]
.github/workflows/check-snapshots.yml:83:9: shellcheck reported issue in this script: SC2236:style:3:7: Use -n instead of ! -z [shellcheck]
.github/workflows/check-snapshots.yml:83:9: shellcheck reported issue in this script: SC2006:style:10:12: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/check-snapshots.yml:83:9: shellcheck reported issue in this script: SC2086:info:14:17: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/check-snapshots.yml:83:9: shellcheck reported issue in this script: SC2086:info:16:9: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/check-snapshots.yml:83:9: shellcheck reported issue in this script: SC2086:info:23:14: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:49:9: shellcheck reported issue in this script: SC2059:info:2:8: Don't use variables in the printf format string. Use printf '..%s..' "$foo" [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2006:style:4:7: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2006:style:5:11: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2006:style:7:11: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2006:style:8:10: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2129:style:11:1: Consider using { cmd1; cmd2; } >> file instead of individual redirects [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:11:30: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:12:30: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:13:28: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:14:36: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:15:112: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:16:120: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:61:9: shellcheck reported issue in this script: SC2086:info:17:60: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2006:style:5:27: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2129:style:12:1: Consider using { cmd1; cmd2; } >> file instead of individual redirects [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2006:style:12:29: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2086:info:12:75: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2086:info:13:64: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2006:style:14:29: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:82:9: shellcheck reported issue in this script: SC2086:info:14:76: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:101:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:101:9: shellcheck reported issue in this script: SC2006:style:5:17: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:101:9: shellcheck reported issue in this script: SC2086:info:7:15: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:101:9: shellcheck reported issue in this script: SC2086:info:12:20: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:119:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:127:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:127:9: shellcheck reported issue in this script: SC2006:style:4:13: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:127:9: shellcheck reported issue in this script: SC2006:style:7:19: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:127:9: shellcheck reported issue in this script: SC2006:style:8:19: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:127:9: shellcheck reported issue in this script: SC2086:info:16:3: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:147:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:163:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:163:9: shellcheck reported issue in this script: SC2006:style:5:13: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/fedora-copr-build.yml:163:9: shellcheck reported issue in this script: SC2086:info:7:17: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:181:9: shellcheck reported issue in this script: SC2236:style:2:4: Use -n instead of ! -z [shellcheck]
.github/workflows/fedora-copr-build.yml:181:9: shellcheck reported issue in this script: SC2086:info:14:21: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/fedora-copr-build.yml:181:9: shellcheck reported issue in this script: SC2006:style:19:40: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/mass-rebuild-reporter.yml:52:9: shellcheck reported issue in this script: SC2086:info:3:29: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/mass-rebuild-reporter.yml:52:9: shellcheck reported issue in this script: SC2086:info:12:6: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/mass-rebuild-reporter.yml:52:9: shellcheck reported issue in this script: SC2086:info:12:24: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/mass-rebuild-reporter.yml:52:9: shellcheck reported issue in this script: SC2086:info:13:29: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/mass-rebuild-reporter.yml:52:9: shellcheck reported issue in this script: SC2086:info:15:28: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/mass-rebuild-reporter.yml:73:9: shellcheck reported issue in this script: SC2086:info:2:42: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/mass-rebuild-runner.yml:30:9: shellcheck reported issue in this script: SC2059:info:2:8: Don't use variables in the printf format string. Use printf '..%s..' "$foo" [shellcheck]
.github/workflows/retest.yml:71:24: "github.event.comment.body" is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable. see https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions for more details [expression]
.github/workflows/retest.yml:82:9: shellcheck reported issue in this script: SC2086:info:2:17: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2006:style:12:15: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2086:info:20:38: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2086:info:26:28: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2006:style:32:23: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2086:info:34:48: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2086:info:35:58: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2006:style:37:20: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2086:info:37:38: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2006:style:38:25: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/sync-on-llvm-version.yml:62:9: shellcheck reported issue in this script: SC2086:info:38:48: Double quote to prevent globbing and word splitting [shellcheck]
.github/workflows/update-build-time-diagrams.yml:37:9: shellcheck reported issue in this script: SC2059:info:2:8: Don't use variables in the printf format string. Use printf '..%s..' "$foo" [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2046:warning:2:79: Quote this to prevent word splitting [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2006:style:2:79: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2046:warning:3:79: Quote this to prevent word splitting [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2006:style:3:79: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2046:warning:4:73: Quote this to prevent word splitting [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2006:style:4:73: Use $(...) notation instead of legacy backticks `...` [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2078:error:13:7: This expression is constant. Did you forget a $ somewhere? [shellcheck]
.github/workflows/update-build-time-diagrams.yml:65:9: shellcheck reported issue in this script: SC2078:error:13:31: This expression is constant. Did you forget a $ somewhere? [shellcheck]
```

