### PR TITLE
Remove project/... label functionalities

### DIFF
--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -127,12 +127,12 @@ of the LLVM (v{llvm_release}, <a href="https://github.com/llvm/llvm-project/comm
 <summary>At certain intervals the CI system will update this very comment over time to reflect the progress of builds.</summary>
 <dl>
 <dt>Log analysis</dt>
-<dd>For example if a build of the <code>llvm</code> project fails on the <code>fedora-rawhide-x86_64</code> platform,
+<dd>For example if a build fails on the <code>fedora-rawhide-x86_64</code> platform,
 we'll analyze the build log (if any) to identify the cause of the failure. The cause can be any of <code>{build_status.ErrorCause.list()}</code>.
 For each cause we will list the packages and the relevant log excerpts.</dd>
 <dt>Use of labels</dt>
 <dd>Let's assume a unit test test in upstream LLVM was broken.
-We will then add these labels to this issue: <code>error/test</code>, <code>build_failed_on/fedora-rawhide-x86_64</code>, <code>project/llvm</code>.
+We will then add these labels to this issue: <code>error/test</code>, <code>build_failed_on/fedora-rawhide-x86_64</code>.
 If you manually restart a build in Copr and can bring it to a successful state, we will automatically
 remove the aforementioned labels.
 </dd>
@@ -259,10 +259,6 @@ remove the aforementioned labels.
     def get_build_failed_on_names_on_issue(cls, issue: github.Issue.Issue) -> list[str]:
         return cls.get_label_names_on_issue(issue, prefix="build_failed_on/")
 
-    @classmethod
-    def get_project_label_names_on_issue(cls, issue: github.Issue.Issue) -> list[str]:
-        return cls.get_label_names_on_issue(issue, prefix="project/")
-
     def create_labels_for_error_causes(
         self, labels: list[str], **kw_args
     ) -> list[github.Label.Label]:
@@ -275,13 +271,6 @@ remove the aforementioned labels.
     ) -> list[github.Label.Label]:
         return self.create_labels(
             labels=labels, prefix="build_failed_on/", color="F9D0C4", **kw_args
-        )
-
-    def create_labels_for_projects(
-        self, labels: list[str], **kw_args
-    ) -> list[github.Label.Label]:
-        return self.create_labels(
-            labels=labels, prefix="project/", color="BFDADC", **kw_args
         )
 
     def create_labels_for_strategies(

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -439,7 +439,6 @@ class SnapshotManager:
     ):
         logging.info("Gather labels based on the errors we've found")
         error_labels = list({f"error/{err.err_cause}" for err in errors})
-        project_labels = list({f"project/{err.package_name}" for err in errors})
         build_failed_on_labels = list(
             {f"build_failed_on/{err.chroot}" for err in errors}
         )
@@ -457,7 +456,6 @@ class SnapshotManager:
         )
         self.github.create_labels_for_error_causes(error_labels)
         self.github.create_labels_for_build_failed_on(build_failed_on_labels)
-        self.github.create_labels_for_projects(project_labels)
         self.github.create_labels_for_strategies(strategy_labels)
         self.github.create_labels_for_in_testing(all_chroots)
         self.github.create_labels_for_tested_on(all_chroots)
@@ -470,13 +468,11 @@ class SnapshotManager:
 
         labels_to_be_removed: list[str] = []
         old_error_labels = self.github.get_error_label_names_on_issue(issue=issue)
-        old_project_labels = self.github.get_project_label_names_on_issue(issue=issue)
         old_build_failed_labels = self.github.get_build_failed_on_names_on_issue(
             issue=issue
         )
 
         labels_to_be_removed.extend(set(old_error_labels) - set(error_labels))
-        labels_to_be_removed.extend(set(old_project_labels) - set(project_labels))
         labels_to_be_removed.extend(
             set(old_build_failed_labels) - set(build_failed_on_labels)
         )
@@ -487,11 +483,7 @@ class SnapshotManager:
 
         # Labels must be added or removed manually in order to not remove manually added labels :/
         labels_to_add = (
-            error_labels
-            + project_labels
-            + build_failed_on_labels
-            + strategy_labels
-            + other_labels
+            error_labels + build_failed_on_labels + strategy_labels + other_labels
         )
         logging.info(f"Adding label: {labels_to_add}")
         issue.add_to_labels(*labels_to_add)

--- a/snapshot_manager/tests/github_util_test.py
+++ b/snapshot_manager/tests/github_util_test.py
@@ -282,12 +282,6 @@ def label_testdata(only_ids: bool = False):
             lambda lbl: MyLabel(name=f"build_failed_on/{lbl}", color="F9D0C4"),
         ),
         (
-            "create_labels_for_projects",
-            "myproject",
-            lambda gh, labels: gh.create_labels_for_projects(labels=labels),
-            lambda lbl: MyLabel(name=f"project/{lbl}", color="BFDADC"),
-        ),
-        (
             "create_labels_for_strategies",
             "mystrategy",
             lambda gh, labels: gh.create_labels_for_strategies(labels=labels),
@@ -349,7 +343,7 @@ def test_get_label_names_on_issue(issue_mock: mock.Mock):
     issue_mock.get_labels.return_value = [
         MyLabel(name="error/foo"),
         MyLabel(name="error/bar"),
-        MyLabel(name="project/clang"),
+        MyLabel(name="tested_on/fedora-rawhide-x86_64"),
     ]
     actual = github_util.GithubClient.get_label_names_on_issue(
         issue=issue_mock, prefix="error/"
@@ -363,7 +357,7 @@ def test_get_error_label_names_on_issue(issue_mock: mock.Mock):
     issue_mock.get_labels.return_value = [
         MyLabel(name="error/foo"),
         MyLabel(name="error/bar"),
-        MyLabel(name="project/clang"),
+        MyLabel(name="tested_on/fedora-rawhide-x86_64"),
     ]
     actual = github_util.GithubClient.get_error_label_names_on_issue(issue=issue_mock)
     expected = ["error/foo", "error/bar"]
@@ -375,24 +369,12 @@ def test_get_build_failed_on_names_on_issue(issue_mock: mock.Mock):
     issue_mock.get_labels.return_value = [
         MyLabel(name="build_failed_on/foo"),
         MyLabel(name="build_failed_on/bar"),
-        MyLabel(name="project/clang"),
+        MyLabel(name="tested_on/fedora-rawhide-x86_64"),
     ]
     actual = github_util.GithubClient.get_build_failed_on_names_on_issue(
         issue=issue_mock
     )
     expected = ["build_failed_on/foo", "build_failed_on/bar"]
-    assert actual == expected
-
-
-@mock.patch("github.Issue.Issue", autospec=True)
-def test_get_project_label_names_on_issue(issue_mock: mock.Mock):
-    issue_mock.get_labels.return_value = [
-        MyLabel(name="build_failed_on/foo"),
-        MyLabel(name="build_failed_on/bar"),
-        MyLabel(name="project/clang"),
-    ]
-    actual = github_util.GithubClient.get_project_label_names_on_issue(issue=issue_mock)
-    expected = ["project/clang"]
     assert actual == expected
 
 
@@ -487,14 +469,16 @@ def test_create_or_update_comment__edit(
 def test_remove_labels_safe(issue_mock: mock.Mock):
     issue_mock.get_labels.return_value = [
         MyLabel(name="build_failed_on/fedora-rawhide-s390x"),
-        MyLabel(name="project/clang"),
+        MyLabel(name="tested_on/fedora-rawhide-x86_64"),
     ]
 
     github_util.GithubClient.remove_labels_safe(
-        issue=issue_mock, label_names_to_be_removed=["project/clang"]
+        issue=issue_mock, label_names_to_be_removed=["tested_on/fedora-rawhide-x86_64"]
     )
 
-    issue_mock.remove_from_labels.assert_called_once_with("project/clang")
+    issue_mock.remove_from_labels.assert_called_once_with(
+        "tested_on/fedora-rawhide-x86_64"
+    )
 
 
 def test_minimize_comment_as_outdated__with_issue_comment(github_client_fxt):
@@ -706,7 +690,7 @@ def test_flip_test_label(github_client_fxt):
     new_label = f"tests_failed_on/{chroot}"
 
     issue_mock.get_labels.return_value = [
-        MyLabel(name="project/clang"),
+        MyLabel(name="error/test"),
         # This will be removed
         MyLabel(name="in_testing/fedora-rawhide-x86_64"),
         MyLabel(name="tested_on/fedora-rawhide-ppc64le"),
@@ -730,7 +714,7 @@ def test_flip_test_label__already_present(github_client_fxt):
     new_label = f"tests_failed_on/{chroot}"
 
     issue_mock.get_labels.return_value = [
-        MyLabel(name="project/clang"),
+        MyLabel(name="error/tests"),
         MyLabel(name="tests_failed_on/fedora-rawhide-x86_64"),
         MyLabel(name="tested_on/fedora-rawhide-ppc64le"),
     ]


### PR DESCRIPTION
We will no longer add `project/...` labels to our issues because we're only building the one big `llvm` project for a while now. We could invest in better classification of LLVM sub-projects as described in [this issue](#579) but that's a different story. For now, let's remove the `project/...` label facility.

NOTE: In places where the testing code was using `project/clang` for example, I've picked another label that doesn't interfere with the test.

Fixes: #1103
See: #579