### PR TITLE
Remove obsolete build time diagrams

### DIFF
--- a/.github/workflows/update-build-time-diagrams.yml
+++ b/.github/workflows/update-build-time-diagrams.yml
@@ -65,13 +65,12 @@ jobs:
           create_diagrams: ${{ github.event_name == 'schedule' && true || github.event.inputs.create_diagrams }}
         run: |
           if ${{ env.get_stats }}; then
-            main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-incubator-$(date '+%Y%m%d')" | tee -a gh-pages/build-stats.csv
             main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-big-merge-$(date '+%Y%m%d')" | tee -a gh-pages/build-stats-big-merge.csv
             main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-pgo-$(date '+%Y%m%d')" | tee -a gh-pages/build-stats-pgo.csv
-            git -C gh-pages add build-stats.csv build-stats-big-merge.csv build-stats-pgo.csv
+            git -C gh-pages add build-stats-big-merge.csv build-stats-pgo.csv
           fi
           if ${{ env.create_diagrams }}; then
-            main/scripts/create-diagrams.py --datafile gh-pages/build-stats.csv --datafile-big-merge gh-pages/build-stats-big-merge.csv --datafile-pgo gh-pages/build-stats-pgo.csv
+            main/scripts/create-diagrams.py --datafile-big-merge gh-pages/build-stats-big-merge.csv --datafile-pgo gh-pages/build-stats-pgo.csv
             mv index.html gh-pages/index.html
             mv fig-*.html gh-pages/
             git -C gh-pages add index.html fig-*.html

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+.PHONY: build-diagrams
+build-diagrams:
+	$(eval temp_dir:=$(shell mktemp -d))
+	$(eval yyyymmdd:=$(shell date '+%Y%m%d'))
+	git show origin/gh-pages:build-stats-big-merge.csv > $(temp_dir)/build-stats-big-merge.csv
+	git show origin/gh-pages:build-stats-pgo.csv > $(temp_dir)/build-stats-pgo.csv
+	scripts/get-build-stats.py --copr-projectname "llvm-snapshots-big-merge-$(yyyymmdd)" | tee -a $(temp_dir)/build-stats-big-merge.csv
+	scripts/get-build-stats.py --copr-projectname "llvm-snapshots-pgo-$(yyyymmdd)" | tee -a $(temp_dir)/build-stats-pgo.csv
+	scripts/create-diagrams.py --datafile-big-merge $(temp_dir)/build-stats-big-merge.csv --datafile-pgo $(temp_dir)/build-stats-pgo.csv
+	xdg-open index.html
+
 .PHONY: test-snapshot-manager
 test-snapshot-manager:
 	# pytest --doctest-modules

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ image:https://github.com/fedora-llvm-team/llvm-snapshots/actions/workflows/check
 image:https://github.com/fedora-llvm-team/llvm-snapshots/actions/workflows/python-format-and-tests.yml/badge.svg[link="https://github.com/fedora-llvm-team/llvm-snapshots/actions/workflows/python-format-and-tests.yml"]
 image:https://github.com/fedora-llvm-team/llvm-snapshots/actions/workflows/update-build-time-diagrams.yml/badge.svg[link="https://github.com/fedora-llvm-team/llvm-snapshots/actions/workflows/update-build-time-diagrams.yml"]
 image:https://img.shields.io/badge/code%20style-black-000000.svg[link="https://github.com/psf/black"]
-link:https://fedora-llvm-team.github.io/llvm-snapshots/fig-llvm.html[Build time Diagrams]
+link:https://fedora-llvm-team.github.io/llvm-snapshots/index.html[Build time Diagrams]
 image:https://coveralls.io/repos/github/fedora-llvm-team/llvm-snapshots/badge.svg[link="https://coveralls.io/github/fedora-llvm-team/llvm-snapshots"]
 
 == Maintaining the LLVM Snapshots for Fedora

--- a/scripts/create-diagrams.py
+++ b/scripts/create-diagrams.py
@@ -2,7 +2,6 @@
 
 # %%
 import argparse
-import re
 from datetime import datetime
 from pathlib import Path
 
@@ -11,7 +10,6 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import plotly.io as pio
-from plotly.offline import plot
 
 
 # %%
@@ -115,35 +113,23 @@ def save_figure(fig: go.Figure, filepath: str) -> None:
     )
 
 
-def add_html_header_menu(
-    filepath: str, all_packages: list[str], plotly_div_id: str = "plotly_div_id"
-) -> None:
+def add_html_header_menu(filepath: str, plotly_div_id: str = "plotly_div_id") -> None:
     """Replace plotly's opening HTML-div element with itself and an additional
-       menu so that you can navigate from any package to any other package
-       without needing to visit the index again.
+       menu so that you can navigate to different pages.
 
     Args:
         filepath (str): HTML file in which to do the replacement.
-        all_packages (str]): All the packages names for which to generate a menu entry
         plotly_div_id (str, optional): Plotly's HTML div's ID. Defaults to "plotly_div_id".
     """
     replace_me = f'<div id="{plotly_div_id}"'
 
+    last_updated = datetime.today().strftime("%c")
+
     file = Path(filepath)
-    header_menu = '<div id="headermenu">Build-Stats by package: '
-    header_menu += " | ".join(
-        [
-            '<a href="fig-{package_name}.html">{package_name}</a> '.format(
-                package_name=package_name
-            )
-            for package_name in all_packages
-        ]
-    )
-    header_menu += (
-        ' | <a href="fig-combined-standalone.html">llvm+clang+compiler-rt+libomp</a>'
-    )
-    header_menu += ' | <a href="fig-big-merge.html">llvm (big-merge)</a>'
+    header_menu = '<div id="headermenu">Build-Stats: '
+    header_menu += ' <a href="index.html">llvm (big-merge)</a>'
     header_menu += ' | <a href="fig-pgo.html">llvm (pgo)</a>'
+    header_menu += f" <small>(Last updated: {last_updated})</small>"
     header_menu += "</div>"
     header_menu += replace_me
 
@@ -151,11 +137,11 @@ def add_html_header_menu(
 
 
 # %%
-def prepare_data(filepath: str = "build-stats.csv") -> pd.DataFrame:
+def prepare_data(filepath: str = "build-stats-big-merge.csv") -> pd.DataFrame:
     """Reads in data from a given file in CSV format, sort it and removes duplicates
 
     Args:
-        filepath (str, optional): The path to the CSV file to read in. Defaults to 'build-stats.csv'.
+        filepath (str, optional): The path to the CSV file to read in. Defaults to 'build-stats-merge.csv'.
 
     Returns:
         pd.DataFrame: A prepared and ready to use dataframe
@@ -190,104 +176,11 @@ def prepare_data(filepath: str = "build-stats.csv") -> pd.DataFrame:
     return df
 
 
-def prepare_data_combined(
-    filepath: str = "build-stats.csv",
-    package_names: list[str] = ["llvm", "clang", "compiler-rt", "libomp"],
-) -> pd.DataFrame:
-    """Same as prepare_data but it combines builds of the given packages.
-
-    The combination groups rows by their date and chroot and then sums up the build times.
-    Columns like "package", "build_id", or "state" will be changed into lists.
-
-    Args:
-        filepath (str, optional): The path to the CSV file to read in. Defaults to "build-stats.csv".
-        package_names (list[str], optional): List of package names that will be combined. Defaults to ["llvm", "clang", "compiler-rt", "libomp"].
-
-    Returns:
-        pd.DataFrame: A dataframe that contains only entries for the given package_names.
-    """
-    df = prepare_data(filepath=filepath)
-
-    # limit to only those rows that are
-    df = df[df.package.isin(package_names)]
-    df = (
-        df.groupby(by=["date", "chroot"], as_index=False)
-        .agg(
-            {
-                "build_time_secs": "sum",
-                "package": lambda x: list(x),
-                "state": lambda x: list(x),
-                "build_id": lambda x: list(x),
-                "timestamp": "max",
-            }
-        )
-        .reset_index()
-    )
-
-    # Overwrite the "build_time" column with the sum of build times for all packages within this group
-    df["build_time"] = np.array(
-        pd.to_timedelta(df.build_time_secs, unit="seconds")
-    ) + pd.to_datetime("1970/01/01")
-
-    return df
-
-
-def create_index_page(all_packages: list[str], filepath: str = "index.html") -> None:
-    """Create an index HTML overview page that links to each figure page
-
-    Args:
-        all_packages (str]): A list of package names
-        filepath (str, optional): File name to use when saving the index page. Defaults to 'index.html'.
-    """
-    with open(filepath, "w") as f:
-        template = """
-    <!DOCTYPE html>
-    <html lang="en">
-        <head>
-            <meta charset="utf-8" />
-            <title>{title}</title>
-        </head>
-        <body>
-            <h1>{title}</h1>
-            <ul>
-                {package_link_items}
-                <li><a href="fig-combined-standalone.html">llvm+clang+compiler-rt+libomp</a></li>
-                <li><a href="fig-big-merge.html">llvm (big-merge)</a></li>
-                <li><a href="fig-pgo.html">llvm (pgo)</a></li>
-            </ul>
-            <hr/>
-            <small>Last updated: {last_updated}</small>
-        </body>
-    </html>
-        """
-        package_link_items = "\n".join(
-            [
-                '<li><a href="fig-{package_name}.html">{package_name}</a></li>'.format(
-                    package_name=package_name
-                )
-                for package_name in all_packages
-            ]
-        )
-        html_str = template.format(
-            package_link_items=package_link_items,
-            title="Build times for the LLVM snapshot packages",
-            last_updated=datetime.today().strftime("%c"),
-        )
-        f.write(html_str)
-
-
 def main() -> None:
     """The main program to prepare the data, generate figures, save them and create an index page for them."""
 
     parser = argparse.ArgumentParser(
         description="Create build time diagrams for a given CSV file"
-    )
-    parser.add_argument(
-        "--datafile",
-        dest="datafile",
-        type=str,
-        default="build-stats.csv",
-        help="path to your build-stats.csv file",
     )
     parser.add_argument(
         "--datafile-big-merge",
@@ -312,70 +205,31 @@ def main() -> None:
         "plotly"  # See https://plotly.com/python/templates/#theming-and-templates
     )
 
-    # Get the data to render out
-    df = prepare_data(filepath=args.datafile)
-
-    # Get a list of unique package names and sort them
-    all_packages = df.package.unique()
-    all_packages.sort()
-
-    # Create and safe a figure as an HTML file for each package.
-    for package_name in all_packages:
-        fig = create_figure(df=df, package_name=package_name)
-        # To debug, uncomment the following:
-        # fig.show()
-        # break
-        filepath = f"fig-{package_name}.html"
-        save_figure(fig=fig, filepath=filepath)
-        add_html_header_menu(filepath=filepath, all_packages=all_packages)
-
-    # Create dataframe of llvm, clang, compiler-rt and libomp combined in
-    # standalone-mode
-    df_combined = prepare_data_combined(
-        filepath=args.datafile,
-        package_names=["llvm", "clang", "compiler-rt", "libomp"],
-    )
-
-    # Create dataframe of llvm, clang, compiler-rt and libomp but when build in
-    # big-merge mode. The chroots are prefixed with "big-merge-" on the fly to
-    # be able to distinguish the two cases.
+    # Create dataframe of llvm in "big-merge mode". The chroots are prefixed
+    # with "big-merge-" on the fly to be able to distinguish the two cases.
     df_big_merge = prepare_data(filepath=args.datafile_big_merge)
     df_big_merge["chroot"] = "big-merge-" + df_big_merge["chroot"]
-    # Convert build_id column with int64's in it to an array of int64's to match
-    # that of the combined standalone dataframe above (see: df_combined).
+    # Convert build_id column with int64's in it to an array of int64's.
     df_big_merge.build_id = df_big_merge.build_id.apply(lambda x: [x])
 
-    # Create dataframe of llvm, clang, compiler-rt and libomp but when build in
-    # pgo mode. The chroots are prefixed with "pgo-" on the fly to
-    # be able to distinguish the two cases.
+    # Create dataframe for PGO builds. The chroots are prefixed with "pgo-" on
+    # the fly to be able to distinguish the two cases.
     df_pgo = prepare_data(filepath=args.datafile_pgo)
     df_pgo["chroot"] = "pgo-" + df_pgo["chroot"]
-    # Convert build_id column with int64's in it to an array of int64's to match
-    # that of the combined standalone dataframe above (see: df_combined).
+    # Convert build_id column with int64's in it to an array of int64's.
     df_pgo.build_id = df_pgo.build_id.apply(lambda x: [x])
-
-    # Concat the three dataframes of combined standalone and big-merge
-    df_result = pd.concat([df_combined, df_big_merge, df_pgo])
-
-    fig = create_figure(df=df_result)
-    filepath = "fig-combined-standalone.html"
-    save_figure(fig=fig, filepath=filepath)
-    add_html_header_menu(filepath=filepath, all_packages=all_packages)
 
     # Create dedicated big-merge figure with nothing else in it.
     fig = create_figure(df=df_big_merge)
-    filepath = "fig-big-merge.html"
+    filepath = "index.html"
     save_figure(fig=fig, filepath=filepath)
-    add_html_header_menu(filepath=filepath, all_packages=all_packages)
+    add_html_header_menu(filepath=filepath)
 
-    # Create dedicated big-merge figure with nothing else in it.
+    # Create dedicated PGO figure with nothing else in it.
     fig = create_figure(df=df_pgo)
     filepath = "fig-pgo.html"
     save_figure(fig=fig, filepath=filepath)
-    add_html_header_menu(filepath=filepath, all_packages=all_packages)
-
-    # Create an index HTML overview page that links to each figure page
-    create_index_page(all_packages=all_packages, filepath="index.html")
+    add_html_header_menu(filepath=filepath)
 
 
 if __name__ == "__main__":

--- a/scripts/create-diagrams.py
+++ b/scripts/create-diagrams.py
@@ -137,11 +137,11 @@ def add_html_header_menu(filepath: str, plotly_div_id: str = "plotly_div_id") ->
 
 
 # %%
-def prepare_data(filepath: str = "build-stats-big-merge.csv") -> pd.DataFrame:
+def prepare_data(filepath: str) -> pd.DataFrame:
     """Reads in data from a given file in CSV format, sort it and removes duplicates
 
     Args:
-        filepath (str, optional): The path to the CSV file to read in. Defaults to 'build-stats-merge.csv'.
+        filepath (str, optional): The path to the CSV file to read in.
 
     Returns:
         pd.DataFrame: A prepared and ready to use dataframe


### PR DESCRIPTION
This change does different things at once.

1. No longer use `build-stats.csv` but only `build-stats-big-merge.csv` and `build-stats-pgo.csv`. The latter has been there before and might be useful in the future.

2. The `index.html` landing page with an overview of packages got removed because with the advent of big-merge we only have the llvm package.

3. The new `index.html` is what formerly was the `fig-big-merge.html`.

4. The `Makefile` contains a new recipe for you to produce the diagrams locally for testing.

5. The "big-merge" way of building allowed me to remove a lot of code which previously was needed to merge individual packages together.

This is how the new page looks: 
![image](https://github.com/user-attachments/assets/4f28dd46-d451-4306-aca4-79513cdb4de1)


Fixes: #1046 