### PR TITLE
[build-diagrams] show successful builds by default

### DIFF
--- a/scripts/create-diagrams.py
+++ b/scripts/create-diagrams.py
@@ -209,11 +209,11 @@ def main() -> None:
         "plotly"  # See https://plotly.com/python/templates/#theming-and-templates
     )
 
-    # # Create dataframe of llvm in "big-merge mode". The chroots are prefixed
-    # # with "big-merge-" on the fly to be able to distinguish the two cases.
+    # Create dataframe of llvm in "big-merge mode". The chroots are prefixed
+    # with "big-merge-" on the fly to be able to distinguish the two cases.
     df_big_merge = prepare_data(filepath=args.datafile_big_merge)
     df_big_merge["chroot"] = "big-merge-" + df_big_merge["chroot"]
-    # # Convert build_id column with int64's in it to an array of int64's.
+    # Convert build_id column with int64's in it to an array of int64's.
     df_big_merge.build_id = df_big_merge.build_id.apply(lambda x: [x])
 
     filter = df_big_merge["state"] == "succeeded"


### PR DESCRIPTION
* I've removed the PGO builds from the menu because I'm not working on it atm. The files themselves are still written.

* I've added two options to view big-merge stats:

  1. *Only successful builds*, which is the default, will give a very good overview of build time evolution.

![image](https://github.com/user-attachments/assets/054e6a1e-cbd8-415c-a306-ad3bb25bf0f1)

  3. *All states* shows builds that ended in all possible states (that's what we had before).

![image](https://github.com/user-attachments/assets/a0543ddb-1859-42da-949c-6f2136193892)
