### PR TITLE
Refactor and test copr_util module

### DIFF
--- a/snapshot_manager/tests/copr_util_test.py
+++ b/snapshot_manager/tests/copr_util_test.py
@@ -1,47 +1,175 @@
 """Tests for copr_client"""
 
+import os
 import uuid
+from unittest import mock
 
+import munch
+import pytest
 import tests.base_test as base_test
 
-import snapshot_manager.config as config
 import snapshot_manager.copr_util as copr_util
+from snapshot_manager.build_status import BuildState, CoprBuildStatus
 
 
-class TestCopr(base_test.TestBase):
-    def test_project_exists(self):
-        """Test if copr project exists."""
-        self.assertTrue(
-            copr_util.CoprClient().project_exists(
-                copr_ownername="@fedora-llvm-team", copr_projectname="llvm-snapshots"
-            )
-        )
+@mock.patch("copr.v3.Client")
+def test_make_client__from_env(client_mock: mock.Mock):
+    myconfig = {
+        "COPR_URL": "myurl",
+        "COPR_LOGIN": "mylogin",
+        "COPR_TOKEN": "mytoken",
+        "COPR_USERNAME": "myusername",
+    }
+    with mock.patch.dict(os.environ, values=myconfig, clear=True):
+        copr_util.make_client()
 
-        rand = str(uuid.uuid4())
-        self.assertFalse(
-            copr_util.CoprClient().project_exists(
-                copr_ownername=rand, copr_projectname=rand
-            )
-        )
+    config = {
+        "copr_url": myconfig["COPR_URL"],
+        "login": myconfig["COPR_LOGIN"],
+        "token": myconfig["COPR_TOKEN"],
+        "username": myconfig["COPR_USERNAME"],
+    }
+    client_mock.assert_called_once_with(config)
 
-    def test_copr_chroots(self):
-        """Ensure all chroots match the default chroot pattern."""
-        chroots = copr_util.CoprClient().get_copr_chroots()
-        for chroot in chroots:
-            self.assertRegex(chroot, config.Config().chroot_pattern)
 
-    def test_is_package_supported_by_chroot(self):
-        """Test if package is supported by chroot"""
-        self.assertTrue(
-            copr_util.CoprClient.is_package_supported_by_chroot(
-                package="lld", chroot="fedora-rawhide-x86_64"
-            )
-        )
-        self.assertTrue(
-            copr_util.CoprClient.is_package_supported_by_chroot(
-                package="llvm", chroot="fedora-rawhide-x86_64"
-            )
-        )
+@mock.patch("copr.v3.Client")
+def test_make_client__from_file(client_mock: mock.Mock):
+    # Missing a few parameters, so defaulting back to creation from file
+    myconfig = {"COPR_URL": "myurl"}
+    with mock.patch.dict(os.environ, values=myconfig, clear=True):
+        copr_util.make_client()
+    client_mock.create_from_config_file.assert_called_once()
+
+
+@mock.patch("copr.v3.Client")
+def test_get_all_chroots(client_mock: mock.Mock):
+    # When calling the function under test multiple times,
+    # ensure the internal get_list function is only called
+    # once. This is because the result it has to be cached.
+    # by functools.cache.
+    copr_util.get_all_chroots(client=client_mock)
+    copr_util.get_all_chroots(client=client_mock)
+    copr_util.get_all_chroots(client=client_mock)
+    client_mock.mock_chroot_proxy.get_list.assert_called_once()
+
+
+@mock.patch("copr.v3.Client")
+def test_get_all_builds(client_mock: mock.Mock):
+    copr_util.get_all_builds(client=client_mock, ownername="foo", projectname="bar")
+    client_mock.build_proxy.get_list.assert_called_once_with(
+        ownername="foo", projectname="bar"
+    )
+
+
+@mock.patch("copr.v3.helpers.wait")
+@mock.patch("snapshot_manager.copr_util.get_all_builds")
+@mock.patch("copr.v3.Client")
+def test_delete_project(
+    client_mock: mock.Mock, get_all_builds_mock: mock.Mock, wait_mock: mock.Mock
+):
+    # Prepare a set of builds, some "active" and some not.
+    build1 = munch.Munch(id=1, build_id=1, state=CoprBuildStatus.RUNNING)
+    build2 = munch.Munch(id=2, build_id=2, state=CoprBuildStatus.FAILED)
+    build3 = munch.Munch(id=3, build_id=3, state=CoprBuildStatus.PENDING)
+    get_all_builds_mock.return_value = [build1, build2, build3]
+
+    # The actual test call
+    copr_util.delete_project(client=client_mock, ownername="foo", projectname="bar")
+
+    # Assert that the active builds have been called
+    get_all_builds_mock.assert_called_once_with(
+        client=client_mock, ownername="foo", projectname="bar"
+    )
+
+    # Assert that build1 and build3 have been cancelled but not build2
+    assert client_mock.build_proxy.cancel.call_count == 2
+    cancel_call_list = client_mock.build_proxy.cancel.call_args_list
+    cancelled_build_ids = [call.kwargs["build_id"] for call in cancel_call_list]
+    assert build1["build_id"] in cancelled_build_ids
+    assert build2["build_id"] not in cancelled_build_ids
+    assert build3["build_id"] in cancelled_build_ids
+
+    # Assert that we waited on build1 and build3 but not on build2
+    waited_on_builds = wait_mock.call_args.kwargs["waitable"]
+    assert build1 in waited_on_builds
+    assert build2 not in waited_on_builds
+    assert build3 in waited_on_builds
+
+    # Assert that we finally deleted the project
+    client_mock.project_proxy.delete.assert_called_once_with(
+        ownername="foo", projectname="bar"
+    )
+
+
+@mock.patch("copr.v3.Client")
+def test_get_all_build_states(client_mock: mock.Mock):
+    # given
+    ownername = "@fedora-llvm-team"
+    projectname = "llvm-snapshots-big-merge-20250217"
+    chroot1 = {
+        "build_id": 8662297,
+        "state": "succeeded",
+        "url_build_log": "https://download.copr.fedorainfracloud.org/results/@fedora-llvm-team/llvm-snapshots-big-merge-20250217/rhel-9-x86_64/08662297-llvm/builder-live.log.gz",
+    }
+    chroot2 = {
+        "build_id": 8662296,
+        "state": "running",
+        "url_build_log": "https://download.copr.fedorainfracloud.org/results/@fedora-llvm-team/llvm-snapshots-big-merge-20250217/rhel-9-s390x/08662296-llvm/builder-live.log",
+        "url_build": "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-20250217/build/8662296/",
+    }
+    client_mock.monitor_proxy.monitor.return_value = munch.munchify(
+        {
+            "output": "ok",
+            "message": "Project monitor request successful",
+            "packages": [
+                {
+                    "name": "llvm",
+                    "chroots": {
+                        "rhel-9-x86_64": chroot1,
+                        "rhel-9-s390x": chroot2,
+                    },
+                }
+            ],
+        }
+    )
+    # when
+    actual = copr_util.get_all_build_states(
+        client=client_mock, ownername=ownername, projectname=projectname
+    )
+    # then
+    client_mock.monitor_proxy.monitor.assert_called_once_with(
+        ownername=ownername,
+        projectname=projectname,
+        additional_fields=["url_build_log", "url_build"],
+    )
+    expected = [
+        BuildState(
+            err_cause=None,
+            package_name="llvm",
+            chroot="rhel-9-x86_64",
+            url_build_log=chroot1["url_build_log"],
+            url_build="",
+            build_id=chroot1["build_id"],
+            copr_build_state=chroot1["state"],
+            err_ctx="",
+            copr_ownername=ownername,
+            copr_projectname=projectname,
+        ),
+        BuildState(
+            err_cause=None,
+            package_name="llvm",
+            chroot="rhel-9-s390x",
+            url_build_log=chroot2["url_build_log"],
+            url_build=chroot2["url_build"],
+            build_id=chroot2["build_id"],
+            copr_build_state=chroot2["state"],
+            err_ctx="",
+            copr_ownername=ownername,
+            copr_projectname=projectname,
+        ),
+    ]
+
+    assert actual == expected
 
 
 def load_tests(loader, tests, ignore):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1151
* #1150
* #1149
* #1148
* __->__ #1147
* #1146
* #1145

----

Add methods from `scripts/functions.sh` to python:

  * `has_all_good_builds`
  * `delete_project`

These functions will be used in a later commit. The goal is to do most
of the analyis of copr builds in Python and not in bash in
`scripts/functions.sh`.
