### PR TITLE
Simplify the main program and add commands

### DIFF
--- a/snapshot_manager/main.py
+++ b/snapshot_manager/main.py
@@ -4,12 +4,18 @@ import logging
 import sys
 
 import snapshot_manager.config as config
+import snapshot_manager.copr_util as copr_util
 import snapshot_manager.snapshot_manager as snapshot_manager
+import snapshot_manager.util as util
+
+# This shows the default value of arguments in the help text.
+# See https://docs.python.org/3/library/argparse.html#argparse.ArgumentDefaultsHelpFormatter
+ARG_PARSE_SHOW_DEFAULT_VALUE = {
+    "formatter_class": argparse.ArgumentDefaultsHelpFormatter
+}
 
 
 def main():
-    cfg = config.Config()
-
     logging.basicConfig(
         level=logging.INFO,
         format="[%(asctime)s] %(levelname)s [%(filename)s:%(lineno)d %(funcName)s] %(message)s",
@@ -17,22 +23,90 @@ def main():
         stream=sys.stderr,
     )
 
-    # This shows the default value of arguments in the help text.
-    # See https://docs.python.org/3/library/argparse.html#argparse.ArgumentDefaultsHelpFormatter
-    parser_args = {"formatter_class": argparse.ArgumentDefaultsHelpFormatter}
+    cfg = config.Config()
+    args = build_argument_parser(cfg=cfg).parse_args()
+    cmd = args.command
 
+    copr_client = None
+    all_chroots = []
+    config_map = config.build_config_map()
+
+    # For some commands we need a copr client and a config map set up.
+    if cmd in (
+        "check",
+        "get-chroots",
+        "has-all-good-builds",
+        "delete-project",
+        "github-matrix",
+    ):
+        copr_client = copr_util.make_client()
+        all_chroots = copr_util.get_all_chroots(client=copr_client)
+        util.augment_config_map_with_chroots(
+            config_map=config_map, all_chroots=all_chroots
+        )
+
+    if cmd in ("check", "get-chroots", "has-all-good-builds", "delete-project"):
+        if args.strategy not in config_map:
+            logging.error(
+                f"No strategy with name '{args.strategy}' found in list of strategies: {config_map.keys()}"
+            )
+            sys.exit(1)
+        cfg = config_map[args.strategy]
+
+    if cmd == "check":
+        cfg.github_repo = args.github_repo
+        cfg.datetime = args.datetime
+        cfg.strategy = args.strategy
+        snapshot_manager.SnapshotManager(config=cfg).check_todays_builds()
+    elif cmd == "retest":
+        cfg.github_repo = args.github_repo
+        snapshot_manager.SnapshotManager(config=cfg).retest(
+            issue_number=args.issue_number,
+            trigger_comment_id=args.trigger_comment_id,
+            chroots=args.chroots,
+        )
+    elif cmd == "github-matrix":
+        json = util.serialize_config_map_to_github_matrix(
+            config_map=config_map,
+            strategy=args.strategy,
+            lookback_days=args.lookback_days,
+        )
+        print(json)
+    elif cmd == "get-chroots":
+        print(" ".join(cfg.chroots))
+    elif cmd == "delete-project":
+        cfg.datetime = args.datetime
+        copr_util.delete_project(
+            client=copr_client,
+            ownername=cfg.copr_ownername,
+            projectname=cfg.copr_projectname,
+        )
+    elif cmd == "has-all-good-builds":
+        cfg.datetime = args.datetime
+        states = copr_util.get_all_build_states(
+            client=copr_client,
+            ownername=cfg.copr_ownername,
+            projectname=cfg.copr_projectname,
+        )
+        cfg.packages = args.packages
+        builds_succeeded = copr_util.has_all_good_builds(
+            required_chroots=cfg.chroots,
+            required_packages=cfg.packages,
+            states=states,
+        )
+        if not builds_succeeded:
+            logging.warning("Not all builds were successful")
+            sys.exit(1)
+        logging.info("All required builds were successful")
+    else:
+        logging.error(f"Unsupported command: {cmd}")
+        sys.exit(1)
+
+
+def build_argument_parser(cfg: config.Config) -> argparse.ArgumentParser:
     mainparser = argparse.ArgumentParser(
         description="Program for managing LLVM snapshots",
-        **parser_args,
-    )
-
-    mainparser.add_argument(
-        "--github-token-env",
-        metavar="ENV_NAME",
-        type=str,
-        dest="github_token_env",
-        default=cfg.github_token_env,
-        help="Default name of the environment variable which holds the github token",
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
     )
 
     mainparser.add_argument(
@@ -44,26 +118,64 @@ def main():
         help="Repo where to open or update issues.",
     )
 
-    # For config file support see:
-    # https://newini.wordpress.com/2021/06/11/how-to-import-config-file-to-argparse-using-configparser/
-    # subparser_check.add_argument(
-    #     "--config-file",
-    #     type=str,
-    #     nargs="+",
-    #     dest="config_file",
-    #     help="Path to config file?",
-    #     required=False
-    # )
-
     subparsers = mainparser.add_subparsers(help="Command to run", dest="command")
 
-    subparser_retest = subparsers.add_parser(
-        "retest",
-        description="Issues a new testing-farm request for one or more chroots",
-        **parser_args,
+    argument_parser_retest(cfg, subparsers=subparsers)
+    argument_parser_get_chroots(cfg, subparsers=subparsers)
+    argument_parser_delete_project(cfg, subparsers=subparsers)
+    argument_parser_github_matrix(cfg, subparsers=subparsers)
+    argument_parser_check(cfg=cfg, subparsers=subparsers)
+    argument_parser_has_all_good_builds(cfg=cfg, subparsers=subparsers)
+
+    return mainparser
+
+
+def add_strategy_argument(argparser: argparse.ArgumentParser) -> argparse.Action:
+    argparser.add_argument(
+        "--strategy",
+        dest="strategy",
+        type=str,
+        default="",
+        help=f"Strategy to use",
     )
 
-    subparser_retest.add_argument(
+
+def add_yyyymmdd_argument(argparser: argparse.ArgumentParser) -> argparse.Action:
+    return argparser.add_argument(
+        "--yyyymmdd",
+        type=lambda s: datetime.datetime.strptime(s, "%Y%m%d"),
+        dest="datetime",
+        default=datetime.datetime.now().strftime("%Y%m%d"),
+        help="Default day for which to run command",
+    )
+
+
+def argument_parser_has_all_good_builds(cfg: config.Config, subparsers) -> None:
+    sp = subparsers.add_parser(
+        "has-all-good-builds",
+        description="Checks if the given ",
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
+    )
+    sp.add_argument(
+        "--packages",
+        metavar="PKG",
+        type=str,
+        nargs="+",
+        dest="packages",
+        default=["llvm"],
+        help="Which packages check (e.g. llvm)",
+    )
+    add_strategy_argument(sp)
+    add_yyyymmdd_argument(sp)
+
+
+def argument_parser_retest(cfg: config.Config, subparsers) -> None:
+    sp = subparsers.add_parser(
+        "retest",
+        description="Issues a new testing-farm request for one or more chroots",
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
+    )
+    sp.add_argument(
         "--chroots",
         metavar="CHROOT",
         type=str,
@@ -72,16 +184,14 @@ def main():
         required=True,
         help="Which chroots to retest (e.g. fedora-rawhide-x86_64)",
     )
-
-    subparser_retest.add_argument(
+    sp.add_argument(
         "--trigger-comment-id",
         type=int,
         dest="trigger_comment_id",
         required=True,
         help="ID of the comment that contains the /retest <CHROOT> string",
     )
-
-    subparser_retest.add_argument(
+    sp.add_argument(
         "--issue-number",
         type=int,
         dest="issue_number",
@@ -89,118 +199,52 @@ def main():
         help="In what issue number did the comment appear in.",
     )
 
-    subparser_check = subparsers.add_parser(
+
+def argument_parser_get_chroots(cfg: config.Config, subparsers) -> None:
+    sp = subparsers.add_parser(
+        "get-chroots",
+        description="Prints a space separated list of chroots for a given strategy",
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
+    )
+    add_strategy_argument(sp)
+
+
+def argument_parser_delete_project(cfg: config.Config, subparsers) -> None:
+    sp = subparsers.add_parser(
+        "delete-project",
+        description="Deletes a project for the given day and strategy",
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
+    )
+    add_strategy_argument(sp)
+    add_yyyymmdd_argument(sp)
+
+
+def argument_parser_github_matrix(cfg: config.Config, subparsers) -> None:
+    sp = subparsers.add_parser(
+        "github-matrix",
+        description="Prints the github workflow matrix for a given or all strategies",
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
+    )
+    add_strategy_argument(sp)
+    sp.add_argument(
+        "--lookback",
+        metavar="DAY",
+        type=int,
+        nargs="+",
+        dest="lookback_days",
+        default=[0],
+        help="Integers for how many days to look back (0 means just today)",
+    )
+
+
+def argument_parser_check(cfg: config.Config, subparsers) -> None:
+    sp = subparsers.add_parser(
         "check",
         description="Check Copr status and update today's github issue",
-        **parser_args,
+        **ARG_PARSE_SHOW_DEFAULT_VALUE,
     )
-
-    subparser_check.add_argument(
-        "--packages",
-        metavar="PKG",
-        type=str,
-        nargs="+",
-        dest="packages",
-        default=cfg.packages,
-        help="Which packages are required to build?",
-    )
-
-    subparser_check.add_argument(
-        "--chroot-pattern",
-        metavar="REGULAR_EXPRESSION",
-        type=str,
-        dest="chroot_pattern",
-        default=cfg.chroot_pattern,
-        help="Chroots regex pattern for required chroots.",
-    )
-
-    subparser_check.add_argument(
-        "--build-strategy",
-        type=str,
-        dest="build_strategy",
-        default=cfg.build_strategy,
-        help="Build strategy to look for (e.g. 'standalone', 'big-merge', 'bootstrap').",
-    )
-
-    subparser_check.add_argument(
-        "--maintainer-handle",
-        metavar="GITHUB_HANDLE_WITHOUT_AT_SIGN",
-        type=str,
-        dest="maintainer_handle",
-        default=cfg.maintainer_handle,
-        help="Maintainer handle to use for assigning issues.",
-    )
-
-    subparser_check.add_argument(
-        "--copr-ownername",
-        metavar="COPR-OWNWERNAME",
-        type=str,
-        dest="copr_ownername",
-        default=cfg.copr_ownername,
-        help="Copr ownername to check.",
-    )
-
-    subparser_check.add_argument(
-        "--copr-project-tpl",
-        metavar="COPR-PROJECT-TPL",
-        type=str,
-        dest="copr_project_tpl",
-        default=cfg.copr_project_tpl,
-        help="Copr project name to check. 'YYYYMMDD' will be replaced, so make sure you have it in there.",
-    )
-
-    subparser_check.add_argument(
-        "--copr-monitor-tpl",
-        metavar="COPR-MONITOR-TPL",
-        type=str,
-        dest="copr_monitor_tpl",
-        default=cfg.copr_monitor_tpl,
-        help="URL to the Copr monitor page. We'll use this in the issue comment's body, not for querying Copr.",
-        # See https://github.com/python/cpython/issues/113878 for when we can
-        # use the __doc__ of a dataclass field.
-        # help=config.Config.copr_monitor_tpl.__doc__
-    )
-
-    subparser_check.add_argument(
-        "--yyyymmdd",
-        type=lambda s: datetime.datetime.strptime(s, "%Y%m%d"),
-        dest="datetime",
-        default=datetime.datetime.now().strftime("%Y%m%d"),
-        help="Default day for which to check",
-    )
-
-    # if args.config_file:
-    #     config = configparser.ConfigParser()
-    #     config.read(args.config_file)
-    #     defaults = {}
-    #     defaults.update(dict(config.items("Defaults")))
-    #     mainparser.set_defaults(**defaults)
-    #     args = mainparser.parse_args() # Overwrite arguments
-
-    args = mainparser.parse_args()
-
-    cfg.github_token_env = args.github_token_env
-    cfg.github_repo = args.github_repo
-
-    if args.command == "check":
-        cfg.datetime = args.datetime
-        cfg.packages = args.packages
-        cfg.chroot_pattern = args.chroot_pattern
-        cfg.build_strategy = args.build_strategy
-        cfg.maintainer_handle = args.maintainer_handle
-        cfg.copr_ownername = args.copr_ownername
-        cfg.copr_project_tpl = args.copr_project_tpl
-        cfg.copr_monitor_tpl = args.copr_monitor_tpl
-
-        snapshot_manager.SnapshotManager(config=cfg).check_todays_builds()
-    elif args.command == "retest":
-        snapshot_manager.SnapshotManager(config=cfg).retest(
-            issue_number=args.issue_number,
-            trigger_comment_id=args.trigger_comment_id,
-            chroots=args.chroots,
-        )
-    else:
-        logging.error(f"Unsupported argument: {args.command}")
+    add_strategy_argument(sp)
+    add_yyyymmdd_argument(sp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1151
* #1150
* __->__ #1149
* #1148
* #1147
* #1146
* #1145

----

In preparation to get rid of the `scripts/functions.sh` (#1151) these are the
newly added commands to the `main` program:

* `get-chroots`
* `delete-project` (see also #1147)
* `github-matrix` (see also `serialize_config_map_to_github_matrix` from #1146)
* `has_all_good_builds` (see also #1147)

These new commands implement functionality that was previously only
available in bash in `scripts/functions.sh`.
