### PR TITLE
Attempt to mitigate lsb_release error

### DIFF
--- a/.github/actions/prepare-python/action.yml
+++ b/.github/actions/prepare-python/action.yml
@@ -14,6 +14,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Try to mitigate this error:
+    # Error: Unable to locate executable file: lsb_release. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
+    - name: Install lsb-release
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install lsb-release
+
     - name: "Setup python"
       uses: actions/setup-python@v5
       if: "${{ inputs.use-system-python != 'true' }}"


### PR DESCRIPTION
We saw this error before:

```
Error: Unable to locate executable file: lsb_release. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

![image](https://github.com/user-attachments/assets/b1af6191-3447-4ed7-b62a-7edd65de8c4f)
