### PR TITLE
Prevent empty strategy in scheduled workflow run

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -51,12 +51,13 @@ jobs:
     - name: generate-matrix
       id: set-matrix
       run: |
-        # shellcheck disable=SC2086
+        strategy="${{ inputs.strategy }}"
+        [[ -z "$strategy" ]] && strategy="all"
         echo "matrix=$(python3 \
           snapshot_manager/main.py github-matrix \
-          --strategy ${{ inputs.strategy }} \
+          --strategy "$strategy" \
           --lookback-days ${{ inputs.lookback_days }} \
-        )" >> $GITHUB_OUTPUT
+        )" >> "$GITHUB_OUTPUT"
 
   check-snapshot:
     if: github.repository_owner == 'fedora-llvm-team'

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -38,11 +38,12 @@ jobs:
     - name: generate-matrix
       id: set-matrix
       run: |
-        # shellcheck disable=SC2086
+        strategy="${{ inputs.strategy }}"
+        [[ -z "$strategy" ]] && strategy="all"
         echo "matrix=$(python3 \
           snapshot_manager/main.py github-matrix \
-          --strategy ${{ inputs.strategy }} \
-        )" >> $GITHUB_OUTPUT
+          --strategy "$strategy" \
+        )" >> "$GITHUB_OUTPUT"
 
   build-on-copr:
     if: github.repository_owner == 'fedora-llvm-team'

--- a/snapshot_manager/main.py
+++ b/snapshot_manager/main.py
@@ -56,7 +56,6 @@ def main():
     if cmd == "check":
         cfg.github_repo = args.github_repo
         cfg.datetime = args.datetime
-        cfg.strategy = args.strategy
         snapshot_manager.SnapshotManager(config=cfg).check_todays_builds()
     elif cmd == "retest":
         cfg.github_repo = args.github_repo
@@ -135,7 +134,7 @@ def add_strategy_argument(argparser: argparse.ArgumentParser) -> argparse.Action
         "--strategy",
         dest="strategy",
         type=str,
-        default="",
+        required=True,
         help=f"Strategy to use",
     )
 

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -179,16 +179,16 @@ def build_config_map() -> dict[str, Config]:
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD/monitor/",
             chroot_pattern="^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
         ),
-        Config(
-            build_strategy="pgo",
-            copr_target_project="@fedora-llvm-team/llvm-snapshots-pgo",
-            package_clone_url="https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
-            package_clone_ref="pgo",
-            maintainer_handle="kwk",
-            copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
-            copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
-            chroot_pattern="(fedora-41)",
-        ),
+        # Config(
+        #     build_strategy="pgo",
+        #     copr_target_project="@fedora-llvm-team/llvm-snapshots-pgo",
+        #     package_clone_url="https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
+        #     package_clone_ref="pgo",
+        #     maintainer_handle="kwk",
+        #     copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
+        #     copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
+        #     chroot_pattern="(fedora-41)",
+        # ),
     ]
 
     return {config.build_strategy: config for config in configs}

--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -632,6 +632,9 @@ def serialize_config_map_to_github_matrix(
     ...   chroot_pattern="rhel-[8,9]",
     ...   chroots=["rhel-9-ppc64le"]
     ... )
+    >>> s = serialize_config_map_to_github_matrix(strategy="", config_map=config_map, lookback_days=[0,1,2,3])
+    Traceback (most recent call last):
+    ValueError: strategy may not be empty
     >>> s = serialize_config_map_to_github_matrix(strategy="all", config_map=config_map, lookback_days=[0,1,2,3])
     >>> obj = json.loads(s)
     >>> import pprint
@@ -659,6 +662,9 @@ def serialize_config_map_to_github_matrix(
      'name': ['mybuildstrategy', 'mybuildstrategy2'],
      'today_minus_n_days': [0, 1, 2, 3]}
     """
+    if strategy.strip() == "":
+        raise ValueError(f"strategy may not be empty")
+
     res = {
         "name": [],
         "include": [],
@@ -668,7 +674,7 @@ def serialize_config_map_to_github_matrix(
         res["today_minus_n_days"] = lookback_days
 
     for strat in config_map:
-        if strategy in ("all", "", strat):
+        if strategy in ("all", strat):
             res["include"].append(config_map[strat].to_github_dict())
             res["name"].append(strat)
 


### PR DESCRIPTION
When the the workflow `fedora-copr-build.yml` runs on a schedule the `inputs` are empty and no strategy will be provided. In this case we want to run all strategies.

This should fix this error: `main.py github-matrix: error: argument --strategy: expected one argument`

![image](https://github.com/user-attachments/assets/502587bd-3a0a-473a-9e87-dbb6497c2bd7)


For now we don't want pgo builds so I've commented out the config for them.