### PR TITLE
Fix --lookback-days argument for github-matrix command

### DIFF
--- a/snapshot_manager/main.py
+++ b/snapshot_manager/main.py
@@ -226,7 +226,7 @@ def argument_parser_github_matrix(cfg: config.Config, subparsers) -> None:
     )
     add_strategy_argument(sp)
     sp.add_argument(
-        "--lookback",
+        "--lookback-days",
         metavar="DAY",
         type=int,
         nargs="+",


### PR DESCRIPTION
This fixes:

```
Run strategy="big-merge"
  strategy="big-merge"
  [[ -z "$strategy" ]] && strategy="all"
  echo "matrix=$(python3 \
    snapshot_manager/main.py github-matrix \
    --strategy "$strategy" \
    --lookback-days 0 \
  )" >> "$GITHUB_OUTPUT"
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.12.9/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.9/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.9/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.9/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.9/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.9/x64/lib
usage: main.py [-h] [--github-repo OWNER/REPO]
               {retest,get-chroots,delete-project,github-matrix,check,has-all-good-builds}
               ...
main.py: error: unrecognized arguments: --lookback-days 0
```

