### PR TITLE
Fix: 'Client' object has no attribute 'copr'

### DIFF
--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -194,7 +194,7 @@ class SnapshotManager:
 
         logging.info("Get build states from copr")
         states = copr_util.get_all_build_states(
-            client=self.copr.copr,
+            client=self.copr,
             ownername=self.config.copr_ownername,
             projectname=self.config.copr_projectname,
         )


### PR DESCRIPTION
This is caused by a left-over where we had the `CoprClient` class with a `copr` member that featured the `copr.v3.Client` object. Now we keep this object around directly.