### PR TITLE
Fix lookback days argument on scheduled workflow run

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -53,10 +53,16 @@ jobs:
       run: |
         strategy="${{ inputs.strategy }}"
         [[ -z "$strategy" ]] && strategy="all"
+        lookback_days="${{ inputs.lookback_days }}"
+        [[ -z "lookback_days" ]] && lookback_days="0 1 2"
+
+        # We need to disable shellcheck's: "Double quote to prevent globbing and word splitting" (SC2086)
+        # because we we need to pass the lookback days as single DAY arguments.
+        # shellcheck disable=SC2086
         echo "matrix=$(python3 \
           snapshot_manager/main.py github-matrix \
           --strategy "$strategy" \
-          --lookback-days ${{ inputs.lookback_days }} \
+          --lookback-days $lookback_days \
         )" >> "$GITHUB_OUTPUT"
 
   check-snapshot:

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -325,9 +325,7 @@ class SnapshotManager:
                     del requests[chroot]
 
             logging.info(f"Check if all builds in chroot {chroot} have succeeded")
-            builds_succeeded = self.copr.has_all_good_builds(
-                copr_ownername=self.config.copr_ownername,
-                copr_projectname=self.config.copr_projectname,
+            builds_succeeded = copr_util.has_all_good_builds(
                 required_chroots=[chroot],
                 required_packages=self.config.packages,
                 states=states,


### PR DESCRIPTION
This should fix this error upon a scheduled `check-snapshots.yml` workflow run where no input is passed:

```
  strategy=""
  [[ -z "$strategy" ]] && strategy="all"
  echo "matrix=$(python3 \
    snapshot_manager/main.py github-matrix \
    --strategy "$strategy" \
    --lookback-days  \
  )" >> "$GITHUB_OUTPUT"

[...]

usage: main.py github-matrix [-h] --strategy STRATEGY
                             [--lookback-days DAY [DAY ...]]
main.py github-matrix: error: argument --lookback-days: expected at least one argument
```