### PR TITLE
Enable PGO builds and bring in llvm-test-suite

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -117,12 +117,19 @@ jobs:
           # shellcheck disable=SC2207
           chroot_opts=($(for c in ${{ matrix.chroots }}; do echo -n " --chroot $c "; done))
 
+          additional_copr_buildtime_repos=""
+          for repo in ${{ matrix.additional_copr_buildtime_repos }}; do
+            additional_copr_buildtime_repos=" --repo $repo "
+          done
+
+          # shellcheck disable=SC2086
           copr-cli create \
             --instructions "$(cat project-instructions.md)" \
             --description  "$(cat project-description.md)" \
             --unlisted-on-hp on \
             --enable-net on \
             --runtime-repo-dependency "https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/\$distname-\$releasever-\$basearch" \
+            $additional_copr_buildtime_repos \
             --multilib on \
             --appstream off \
             --delete-after-days 32 \

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -21,6 +21,9 @@ class Config:
     )
     """List of packages that are relevant to you."""
 
+    additional_copr_buildtime_repos: list[str] = None
+    """Additional repositories that shall be passed to 'copr create' as '--repo' arguments in order to be available during build time"""
+
     datetime: "datetime.datetime" = datetime.datetime.now()
     """Datetime of today"""
 
@@ -135,9 +138,12 @@ class Config:
         ...   copr_project_tpl="SomeProjectTemplate-YYYYMMDD",
         ...   copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/mycoprgroup/SomeProjectTemplate-YYYYMMDD/monitor/",
         ...   chroot_pattern="^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
-        ...   chroots=["fedora-rawhide-x86_64", "rhel-9-ppc64le"]
+        ...   chroots=["fedora-rawhide-x86_64", "rhel-9-ppc64le"],
+        ...   additional_copr_buildtime_repos=["copr://@fedora-llvm-team/llvm-test-suite", "https://example.com"]
         ... ).to_github_dict())
-        {'chroot_pattern': '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)',
+        {'additional_copr_buildtime_repos': 'copr://@fedora-llvm-team/llvm-test-suite '
+                                            'https://example.com',
+         'chroot_pattern': '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)',
          'chroots': 'fedora-rawhide-x86_64 rhel-9-ppc64le',
          'clone_ref': 'mainbranch',
          'clone_url': 'https://src.fedoraproject.org/rpms/mypackage.git',
@@ -159,6 +165,9 @@ class Config:
             "copr_monitor_tpl": self.copr_monitor_tpl,
             "chroot_pattern": self.chroot_pattern,
             "chroots": " ".join(self.chroots),
+            "additional_copr_buildtime_repos": " ".join(
+                self.additional_copr_buildtime_repos
+            ),
         }
 
 
@@ -179,16 +188,19 @@ def build_config_map() -> dict[str, Config]:
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD/monitor/",
             chroot_pattern="^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
         ),
-        # Config(
-        #     build_strategy="pgo",
-        #     copr_target_project="@fedora-llvm-team/llvm-snapshots-pgo",
-        #     package_clone_url="https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
-        #     package_clone_ref="pgo",
-        #     maintainer_handle="kwk",
-        #     copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
-        #     copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
-        #     chroot_pattern="(fedora-41)",
-        # ),
+        Config(
+            build_strategy="pgo",
+            copr_target_project="@fedora-llvm-team/llvm-snapshots-pgo",
+            package_clone_url="https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
+            package_clone_ref="pgo",
+            maintainer_handle="kwk",
+            copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
+            copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
+            chroot_pattern="^fedora-rawhide-x86_64",
+            additional_copr_buildtime_repos=[
+                "copr://@fedora-llvm-team/llvm-test-suite/"
+            ],
+        ),
     ]
 
     return {config.build_strategy: config for config in configs}

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -21,7 +21,9 @@ class Config:
     )
     """List of packages that are relevant to you."""
 
-    additional_copr_buildtime_repos: list[str] = None
+    additional_copr_buildtime_repos: list[str] = dataclasses.field(
+        default_factory=lambda: []
+    )
     """Additional repositories that shall be passed to 'copr create' as '--repo' arguments in order to be available during build time"""
 
     datetime: "datetime.datetime" = datetime.datetime.now()

--- a/snapshot_manager/snapshot_manager/github_util.py
+++ b/snapshot_manager/snapshot_manager/github_util.py
@@ -107,13 +107,18 @@ class GithubClient:
         # label:broken_snapshot_detected
         query = f"is:issue repo:{github_repo} author:{creator} label:strategy/{strategy} {self.config.yyyymmdd} in:title"
         issues = self.github.search_issues(query)
-        if issues is not None and issues.totalCount > 0:
+        if issues is None:
+            logging.info(f"Found no issue for today ({self.config.yyyymmdd})")
+            return None
+
+        # This is a hack: normally the PaginagedList[Issue] type handles this
+        # for us but without this hack no issue being found.
+        issues.get_page(0)
+        if issues.totalCount > 0:
             logging.info(
                 f"Found today's ({self.config.yyyymmdd}) issue: {issues[0].html_url}"
             )
             return issues[0]
-        logging.info(f"Found no issue for today ({self.config.yyyymmdd})")
-        return None
 
     @property
     def initial_comment(self) -> str:

--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -639,7 +639,8 @@ def serialize_config_map_to_github_matrix(
     >>> obj = json.loads(s)
     >>> import pprint
     >>> pprint.pprint(obj)
-    {'include': [{'chroot_pattern': '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)',
+    {'include': [{'additional_copr_buildtime_repos': '',
+                  'chroot_pattern': '^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)',
                   'chroots': 'fedora-rawhide-x86_64 rhel-9-ppc64le',
                   'clone_ref': 'mainbranch',
                   'clone_url': 'https://src.fedoraproject.org/rpms/mypackage.git',
@@ -649,7 +650,8 @@ def serialize_config_map_to_github_matrix(
                   'copr_target_project': '@mycoprgroup/mycoprproject',
                   'maintainer_handle': 'fakeperson',
                   'name': 'mybuildstrategy'},
-                 {'chroot_pattern': 'rhel-[8,9]',
+                 {'additional_copr_buildtime_repos': '',
+                  'chroot_pattern': 'rhel-[8,9]',
                   'chroots': 'rhel-9-ppc64le',
                   'clone_ref': 'mainbranch2',
                   'clone_url': 'https://src.fedoraproject.org/rpms/mypackage2.git',

--- a/snapshot_manager/tests/testing_farm_util_test.py
+++ b/snapshot_manager/tests/testing_farm_util_test.py
@@ -25,6 +25,7 @@ class TestTestingFarmUtil(base_test.TestBase):
         issue = gh.get_todays_github_issue(
             strategy="big-merge", github_repo="fedora-llvm-team/llvm-snapshots"
         )
+        assert issue is not None
 
         with self.assertRaises(SystemError):
             tf.TestingFarmRequest.make(


### PR DESCRIPTION
This adds `copr://@fedora-llvm-team/llvm-test-suite/` as a build time repo for the PGO copr project.

This also re-enabled the `pgo` strategy in the config.

Fixes #1178