### PR TITLE
Enable same chroots for PGO as for big-merge

### DIFF
--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -198,7 +198,7 @@ def build_config_map() -> dict[str, Config]:
             maintainer_handle="kwk",
             copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
-            chroot_pattern="^fedora-rawhide-x86_64",
+            chroot_pattern="^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
             additional_copr_buildtime_repos=[
                 "copr://@fedora-llvm-team/llvm-test-suite/"
             ],


### PR DESCRIPTION
We will build PGO for non x86 for archs and for fedora >= 41 and RHEL >= 9. But we still want to build for the same chroots as big-merge because we need to make sure we can build for those archictures with the PGO code in the llvm.spec not breaking the normal build.

The expected compile-time performance improvements for x86, fedora < 41 and RHEL8 chroots has to be identical to the current snapshots.