### PR TITLE
Limit build chroots for PGO strategy

### DIFF
--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -198,7 +198,7 @@ def build_config_map() -> dict[str, Config]:
             maintainer_handle="kwk",
             copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
-            chroot_pattern="^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
+            chroot_pattern="^fedora-rawhide-(x86_64|aarch64|ppc64le)|rhel-9-x86_64$",
             additional_copr_buildtime_repos=[
                 "copr://@fedora-llvm-team/llvm-test-suite/"
             ],


### PR DESCRIPTION
Today we say that we had problems on fedora-X-aarch64/ppc64le and RHEL9-x86_64. That's why we only keep those for now to not put too much load on copr.

This is to verify the correctness of the results:

```console
$ python3 snapshot_manager/main.py github-matrix --strategy pgo | jq .
{
  "name": [
    "pgo"
  ],
  "include": [
    {
      "name": "pgo",
      "copr_target_project": "@fedora-llvm-team/llvm-snapshots-pgo",
      "clone_url": "https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
      "clone_ref": "pgo",
      "maintainer_handle": "kwk",
      "copr_ownername": "@fedora-llvm-team",
      "copr_project_tpl": "llvm-snapshots-pgo-YYYYMMDD",
      "copr_monitor_tpl": "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
      "chroot_pattern": "^fedora-rawhide-(x86_64|aarch64|ppc64le)|rhel-9-x86_64$",
      "chroots": "fedora-rawhide-aarch64 fedora-rawhide-ppc64le fedora-rawhide-x86_64 rhel-9-x86_64",
      "additional_copr_buildtime_repos": "copr://@fedora-llvm-team/llvm-test-suite/"
    }
  ],
  "today_minus_n_days": [
    0
  ]
}
```