### PR TITLE
bisect.sh: Use pre-built binaries to bisect failures

### DIFF
--- a/scripts/bisect.sh
+++ b/scripts/bisect.sh
@@ -48,12 +48,11 @@ function test_with_copr_builds {
   dnf copr enable -y $copr_project
   dnf install --best -y clang
   dnf builddep -y $srpm_name
+  # Disable project so future installs don't use it.
+  dnf copr disable $copr_project
   if ! rpmbuild -D '%toolchain clang' -rb $srpm_name; then
     return 1
   fi
-  # Clean up
-  dnf copr disable $good_copr_project
-  dnf remove -y clang
 }
 
 function test_copr_or_commit {
@@ -122,6 +121,30 @@ if test_copr_or_commit $bad_copr_project $bad_commit $srpm_name; then
   echo "False Positive."
   exit 1
 fi
+
+# First attempt to bisect using prebuilt binaries.
+chroot="fedora-$(rpm --eval %{fedora})-$(rpm --eval %{_arch})"
+good=$good_copr_project
+bad=$bad_copr_project
+
+while [ True ]; do
+  test_project=$(python3 rebuilder.py bisect --chroot $chroot --good $good --bad $bad)
+  echo "Trying $test_project"
+
+  if [ "$test_project" = "$good_copr_project" ] || [ "$test_project" = "$bad_copr_project" ]; then
+    break
+  fi
+
+  if test_with_copr_builds $test_project $srpm_name; then
+    good=$test_project
+    good_commit=$(dnf info --installed clang | grep '^Version' | cut -d 'g' -f 2)
+    echo "GOOD"
+  else
+    bad=$test_project
+    bad_commit=$(dnf info --installed clang | grep '^Version' | cut -d 'g' -f 2)
+    echo "BAD"
+  fi
+done
 
 dnf builddep -y $srpm_name
 git bisect start

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -368,11 +368,7 @@ def extract_date_from_project(project_name: str) -> datetime.date:
     return datetime.datetime.fromisoformat(m.group(0)).date()
 
 
-def find_midpoint_project(
-    copr_client: copr.v3.Client,
-    good: str,
-    bad: str,
-    chroot: str
+def find_midpoint_project(copr_client: copr.v3.Client, good: str, bad: str, chroot: str
 ):
     good_date = extract_date_from_project(good)
     bad_date = extract_date_from_project(bad)
@@ -381,11 +377,13 @@ def find_midpoint_project(
     increment = 0
     while mid_date != good_date and mid_date != bad_date:
         mid_project = re.sub("[0-9]+$", mid_date.strftime("%Y%m%d"), good)
-        owner = mid_project.split('/')[0]
-        project = mid_project.split('/')[1]
+        owner = mid_project.split("/")[0]
+        project = mid_project.split("/")[1]
         try:
-            for builds in copr_client.build_proxy.get_list(owner, project, 'llvm', "succeeded"):
-                if chroot in builds['chroots']:
+            for builds in copr_client.build_proxy.get_list(
+                owner, project, "llvm", "succeeded"
+            ):
+                if chroot in builds["chroots"]:
                     return mid_project
         except:
             pass
@@ -412,21 +410,15 @@ def main():
             "get-regressions",
             "get-snapshot-date",
             "rebuild-in-progress",
-            "bisect"
+            "bisect",
         ],
     )
     parser.add_argument(
         "--start-date", type=str, help="Any ISO date format is accepted"
     )
-    parser.add_argument(
-        "--chroot", type=str
-    )
-    parser.add_argument(
-        "--good", type=str
-    )
-    parser.add_argument(
-        "--bad", type=str
-    )
+    parser.add_argument("--chroot", type=str)
+    parser.add_argument("--good", type=str)
+    parser.add_argument("--bad", type=str)
 
     args = parser.parse_args()
     copr_client = copr.v3.Client.create_from_config_file()

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -368,7 +368,8 @@ def extract_date_from_project(project_name: str) -> datetime.date:
     return datetime.datetime.fromisoformat(m.group(0)).date()
 
 
-def find_midpoint_project(copr_client: copr.v3.Client, good: str, bad: str, chroot: str
+def find_midpoint_project(
+    copr_client: copr.v3.Client, good: str, bad: str, chroot: str
 ):
     good_date = extract_date_from_project(good)
     bad_date = extract_date_from_project(bad)
@@ -387,7 +388,7 @@ def find_midpoint_project(copr_client: copr.v3.Client, good: str, bad: str, chro
                     return mid_project
         except:
             pass
-        
+
         increment = increment * -1
         if increment < 0:
             increment -= 1

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -361,6 +361,7 @@ def create_new_project(
             with_opts=["toolchain_clang", "clang_lto"],
         )
 
+
 def extract_date_from_project(project_name: str) -> datetime.date:
     m = re.search("[0-9]+$", project_name)
     if not m:

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -361,6 +361,44 @@ def create_new_project(
             with_opts=["toolchain_clang", "clang_lto"],
         )
 
+def extract_date_from_project(project_name: str) -> datetime.date:
+    m = re.search("[0-9]+$", project_name)
+    if not m:
+        raise Exception(f"Invalid project name: {project_name}")
+    return datetime.datetime.fromisoformat(m.group(0)).date()
+
+
+def find_midpoint_project(
+    copr_client: copr.v3.Client,
+    good: str,
+    bad: str,
+    chroot: str
+):
+    good_date = extract_date_from_project(good)
+    bad_date = extract_date_from_project(bad)
+    days = (bad_date - good_date).days
+    mid_date = good_date + datetime.timedelta(days=days / 2)
+    increment = 0
+    while mid_date != good_date and mid_date != bad_date:
+        mid_project = re.sub("[0-9]+$", mid_date.strftime("%Y%m%d"), good)
+        owner = mid_project.split('/')[0]
+        project = mid_project.split('/')[1]
+        try:
+            for builds in copr_client.build_proxy.get_list(owner, project, 'llvm', "succeeded"):
+                if chroot in builds['chroots']:
+                    return mid_project
+        except:
+            pass
+        
+        increment = increment * -1
+        if increment < 0:
+            increment -= 1
+        else:
+            increment += 1
+        mid_date += datetime.timedelta(days=increment)
+
+    return good
+
 
 def main():
 
@@ -374,10 +412,20 @@ def main():
             "get-regressions",
             "get-snapshot-date",
             "rebuild-in-progress",
+            "bisect"
         ],
     )
     parser.add_argument(
         "--start-date", type=str, help="Any ISO date format is accepted"
+    )
+    parser.add_argument(
+        "--chroot", type=str
+    )
+    parser.add_argument(
+        "--good", type=str
+    )
+    parser.add_argument(
+        "--bad", type=str
     )
 
     args = parser.parse_args()
@@ -437,6 +485,8 @@ def main():
                 if build.is_in_progress():
                     sys.exit(0)
         sys.exit(1)
+    elif args.command == "bisect":
+        print(find_midpoint_project(copr_client, args.good, args.bad, args.chroot))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This will use pre-built binaries for COPR to start the bisect process and find a reduced range of good..bad commits before starting to bisect with local builds of clang.