### PR TITLE
bisect.sh: Install llvm along with clang when bisecting an SRPM

### DIFF
--- a/scripts/bisect.sh
+++ b/scripts/bisect.sh
@@ -44,9 +44,9 @@ function test_with_copr_builds {
   copr_project=$1
   srpm_name=$2
 
-  dnf remove -y clang
+  dnf remove -y clang llvm
   dnf copr enable -y $copr_project
-  dnf install --best -y clang
+  dnf install --best -y clang llvm
   dnf builddep -y $srpm_name
   if ! rpmbuild -D '%toolchain clang' -rb $srpm_name; then
     return 1


### PR DESCRIPTION
Some builds need to use the llvm binutils, like llvm-ar, so we need to make sure these are installed when building packages.