### PR TITLE
[workflow] Add start-performance-comparison.yml

### DIFF
--- a/.github/workflows/start-performance-comparison.yml
+++ b/.github/workflows/start-performance-comparison.yml
@@ -1,0 +1,26 @@
+name: "Start performance comparison"
+
+on:
+  schedule:
+    # Everyday at 00:45am
+    # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+    - cron: "45 0 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  start-performance-comparison:
+    if: github.repository_owner == 'fedora-llvm-team'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-python
+      - name: "start-performance-comparison"
+        run: |
+          today=$(date +%Y%m%d)
+          yesterday=$(date -d "${today} -1 day" +%Y%m%d)
+
+          python3 ./snapshot_manager/main.py start-perf-comparison \
+            --strategy-a pgo \
+            --strategy-b big-merge \
+            --yyyymmdd "$yesterday"


### PR DESCRIPTION
We intend to run performance comparisons on a daily basis. This new
workflow does the first step by running every night close after
midnight.

As a simplification we assume that after 24 hours we have all the
`pgo` and `big-merge` COPR builds ready from the day before.

The new `start-perf-comparison` of the the `main.py` program will be
added in a later PR. To make it easy to follow the PRs I decided to
bring in the necessary changes piece by piece.

---

**Stack**:
- #1267
- #1266
- #1265
- #1264
- #1263
- #1262
- #1261
- #1260
- #1259
- #1258
- #1257
- #1256
- #1255
- #1254 ⬅
- #1253


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*