### PR TITLE
[workflow] Add start-performance-comparison.yml

### DIFF
--- a/.github/workflows/start-performance-comparison.yml
+++ b/.github/workflows/start-performance-comparison.yml
@@ -1,0 +1,26 @@
+name: "Start performance comparison"
+
+on:
+  schedule:
+    # Everyday at 00:45am
+    # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+    - cron: "45 0 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  start-performance-comparison:
+    if: github.repository_owner == 'fedora-llvm-team'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-python
+      - name: "start-performance-comparison"
+        run: |
+          today=$(date +%Y%m%d)
+          yesterday=$(date -d "${today} -1 day" +%Y%m%d)
+
+          python3 ./snapshot_manager/main.py start-perf-comparison \
+            --strategy-a pgo \
+            --strategy-b big-merge \
+            --yyyymmdd "$yesterday"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1282
* #1281
* #1280
* #1279
* #1278
* #1277
* #1276
* #1275
* #1274
* #1273
* #1272
* #1271
* #1270
* __->__ #1269
* #1268

We intend to run performance comparisons on a daily basis. This new
workflow does the first step by running every night close after
midnight.

As a simplification we assume that after 24 hours we have all the
`pgo` and `big-merge` COPR builds ready from the day before.

The new `start-perf-comparison` of the the `main.py` program will be
added in a later PR. To make it easy to follow the PRs I decided to
bring in the necessary changes piece by piece.