### PR TITLE
Add link to "Teach/Ask AI" to each failed build comment

### DIFF
--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -102,7 +102,7 @@ class BuildState:
 
     def render_as_markdown(self) -> str:
         """Return an HTML string representation of this Build State to be used in a github issue"""
-        quoted_build_log_link=urllib.parse.quote(self.build_log_url)
+        quoted_build_log_link = urllib.parse.quote(self.build_log_url)
         link = f'<a href="{self.build_log_url}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">Teach AI</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
         if self.url_build_log is None:
             link = f'<a href="{self.build_page_url}">build page</a>'

--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -103,7 +103,7 @@ class BuildState:
     def render_as_markdown(self) -> str:
         """Return an HTML string representation of this Build State to be used in a github issue"""
         quoted_build_log_link=urllib.parse.quote(self.build_log_url)
-        link = f'<a href="{self.build_log_url}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
+        link = f'<a href="{self.build_log_url}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">Teach AI</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
         if self.url_build_log is None:
             link = f'<a href="{self.build_page_url}">build page</a>'
 

--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -6,6 +6,7 @@ import dataclasses
 import enum
 import logging
 import pathlib
+import urllib
 
 import snapshot_manager.util as util
 
@@ -101,9 +102,11 @@ class BuildState:
 
     def render_as_markdown(self) -> str:
         """Return an HTML string representation of this Build State to be used in a github issue"""
-        link = f'<a href="{self.build_log_url}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">contribute to log-detective</a>'
+        quoted_build_log_link=urllib.parse.quote(self.build_log_url)
+        link = f'<a href="{self.build_log_url}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
         if self.url_build_log is None:
             link = f'<a href="{self.build_page_url}">build page</a>'
+
         return f"""
 <details>
 <summary>

--- a/snapshot_manager/tests/build_status_test.py
+++ b/snapshot_manager/tests/build_status_test.py
@@ -103,7 +103,7 @@ class TestErrorCauseAndBuildStatus(base_test.TestBase):
         expected = """
 <details>
 <summary>
-<code>foo</code> on <code>fedora-40-x86_64</code> (see <a href="https://example.com/url_build_log">build log</a>, <a href="https://logdetective.com/contribute/copr/00001234/fedora-40-x86_64">contribute to log-detective</a>)
+<code>foo</code> on <code>fedora-40-x86_64</code> (see <a href="https://example.com/url_build_log">build log</a>, <a href="https://logdetective.com/contribute/copr/00001234/fedora-40-x86_64">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=https%3A//example.com/url_build_log">Ask AI</a>)
 </summary>
 This is the context for the error
 </details>
@@ -154,42 +154,42 @@ class TestErrorList(base_test.TestBase):
         expected = """<ul><li><b>network_issue</b><ol><li>
 <details>
 <summary>
-<code>package-a</code> on <code>chroot-a</code> (see <a href="http://e1">build log</a>, <a href="https://logdetective.com/contribute/copr/00000111/chroot-a">contribute to log-detective</a>)
+<code>package-a</code> on <code>chroot-a</code> (see <a href="http://e1">build log</a>, <a href="https://logdetective.com/contribute/copr/00000111/chroot-a">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e1">Ask AI</a>)
 </summary>
 e1
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-b</code> on <code>chroot-a</code> (see <a href="http://e2">build log</a>, <a href="https://logdetective.com/contribute/copr/00000222/chroot-a">contribute to log-detective</a>)
+<code>package-b</code> on <code>chroot-a</code> (see <a href="http://e2">build log</a>, <a href="https://logdetective.com/contribute/copr/00000222/chroot-a">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e2">Ask AI</a>)
 </summary>
 e2
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-c</code> on <code>chroot-a</code> (see <a href="http://e3">build log</a>, <a href="https://logdetective.com/contribute/copr/00000333/chroot-a">contribute to log-detective</a>)
+<code>package-c</code> on <code>chroot-a</code> (see <a href="http://e3">build log</a>, <a href="https://logdetective.com/contribute/copr/00000333/chroot-a">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e3">Ask AI</a>)
 </summary>
 e3
 </details>
 </li></ol></li><li><b>test</b><ol><li>
 <details>
 <summary>
-<code>package-a</code> on <code>chroot-c</code> (see <a href="http://e4">build log</a>, <a href="https://logdetective.com/contribute/copr/00000444/chroot-c">contribute to log-detective</a>)
+<code>package-a</code> on <code>chroot-c</code> (see <a href="http://e4">build log</a>, <a href="https://logdetective.com/contribute/copr/00000444/chroot-c">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e4">Ask AI</a>)
 </summary>
 e4
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-b</code> on <code>chroot-c</code> (see <a href="http://e5">build log</a>, <a href="https://logdetective.com/contribute/copr/00000555/chroot-c">contribute to log-detective</a>)
+<code>package-b</code> on <code>chroot-c</code> (see <a href="http://e5">build log</a>, <a href="https://logdetective.com/contribute/copr/00000555/chroot-c">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e5">Ask AI</a>)
 </summary>
 e5
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-c</code> on <code>chroot-c</code> (see <a href="http://e6">build log</a>, <a href="https://logdetective.com/contribute/copr/00000666/chroot-c">contribute to log-detective</a>)
+<code>package-c</code> on <code>chroot-c</code> (see <a href="http://e6">build log</a>, <a href="https://logdetective.com/contribute/copr/00000666/chroot-c">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e6">Ask AI</a>)
 </summary>
 e6
 </details>

--- a/snapshot_manager/tests/build_status_test.py
+++ b/snapshot_manager/tests/build_status_test.py
@@ -103,7 +103,7 @@ class TestErrorCauseAndBuildStatus(base_test.TestBase):
         expected = """
 <details>
 <summary>
-<code>foo</code> on <code>fedora-40-x86_64</code> (see <a href="https://example.com/url_build_log">build log</a>, <a href="https://logdetective.com/contribute/copr/00001234/fedora-40-x86_64">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=https%3A//example.com/url_build_log">Ask AI</a>)
+<code>foo</code> on <code>fedora-40-x86_64</code> (see <a href="https://example.com/url_build_log">build log</a>, <a href="https://logdetective.com/contribute/copr/00001234/fedora-40-x86_64">Teach AI</a>, <a href="https://log-detective.com/explain?url=https%3A//example.com/url_build_log">Ask AI</a>)
 </summary>
 This is the context for the error
 </details>
@@ -154,42 +154,42 @@ class TestErrorList(base_test.TestBase):
         expected = """<ul><li><b>network_issue</b><ol><li>
 <details>
 <summary>
-<code>package-a</code> on <code>chroot-a</code> (see <a href="http://e1">build log</a>, <a href="https://logdetective.com/contribute/copr/00000111/chroot-a">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e1">Ask AI</a>)
+<code>package-a</code> on <code>chroot-a</code> (see <a href="http://e1">build log</a>, <a href="https://logdetective.com/contribute/copr/00000111/chroot-a">Teach AI</a>, <a href="https://log-detective.com/explain?url=http%3A//e1">Ask AI</a>)
 </summary>
 e1
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-b</code> on <code>chroot-a</code> (see <a href="http://e2">build log</a>, <a href="https://logdetective.com/contribute/copr/00000222/chroot-a">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e2">Ask AI</a>)
+<code>package-b</code> on <code>chroot-a</code> (see <a href="http://e2">build log</a>, <a href="https://logdetective.com/contribute/copr/00000222/chroot-a">Teach AI</a>, <a href="https://log-detective.com/explain?url=http%3A//e2">Ask AI</a>)
 </summary>
 e2
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-c</code> on <code>chroot-a</code> (see <a href="http://e3">build log</a>, <a href="https://logdetective.com/contribute/copr/00000333/chroot-a">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e3">Ask AI</a>)
+<code>package-c</code> on <code>chroot-a</code> (see <a href="http://e3">build log</a>, <a href="https://logdetective.com/contribute/copr/00000333/chroot-a">Teach AI</a>, <a href="https://log-detective.com/explain?url=http%3A//e3">Ask AI</a>)
 </summary>
 e3
 </details>
 </li></ol></li><li><b>test</b><ol><li>
 <details>
 <summary>
-<code>package-a</code> on <code>chroot-c</code> (see <a href="http://e4">build log</a>, <a href="https://logdetective.com/contribute/copr/00000444/chroot-c">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e4">Ask AI</a>)
+<code>package-a</code> on <code>chroot-c</code> (see <a href="http://e4">build log</a>, <a href="https://logdetective.com/contribute/copr/00000444/chroot-c">Teach AI</a>, <a href="https://log-detective.com/explain?url=http%3A//e4">Ask AI</a>)
 </summary>
 e4
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-b</code> on <code>chroot-c</code> (see <a href="http://e5">build log</a>, <a href="https://logdetective.com/contribute/copr/00000555/chroot-c">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e5">Ask AI</a>)
+<code>package-b</code> on <code>chroot-c</code> (see <a href="http://e5">build log</a>, <a href="https://logdetective.com/contribute/copr/00000555/chroot-c">Teach AI</a>, <a href="https://log-detective.com/explain?url=http%3A//e5">Ask AI</a>)
 </summary>
 e5
 </details>
 </li><li>
 <details>
 <summary>
-<code>package-c</code> on <code>chroot-c</code> (see <a href="http://e6">build log</a>, <a href="https://logdetective.com/contribute/copr/00000666/chroot-c">contribute to log-detective</a>, <a href="https://log-detective.com/explain?url=http%3A//e6">Ask AI</a>)
+<code>package-c</code> on <code>chroot-c</code> (see <a href="http://e6">build log</a>, <a href="https://logdetective.com/contribute/copr/00000666/chroot-c">Teach AI</a>, <a href="https://log-detective.com/explain?url=http%3A//e6">Ask AI</a>)
 </summary>
 e6
 </details>


### PR DESCRIPTION
I noticed that in COPR we get a new link to "Ask AI" for build failure. I thought it might be good to add this to our build error comments for easy access to the snapshot maintainer.

This is how it looks in Copr:

![image](https://github.com/user-attachments/assets/cbd959f1-4a92-498e-9fe0-ab6f71e27d69)

The "Teach AI" link title is used in COPR so I've changed our "contribute to log-detective" link to "Teach AI" as well.