### PR TITLE
git-bisect-script.sh: Drop fedora-clang-default-cc dependency

### DIFF
--- a/Containerfile.mass-rebuild
+++ b/Containerfile.mass-rebuild
@@ -9,9 +9,7 @@ ENV LLVM_SYSROOT=${llvm_sysroot} \
     AR=llvm-ar \
     RANLIB=llvm-ranlib
 
-RUN dnf -y copr enable tstellar/fedora-clang-default-cc
-
-RUN dnf -y install jq cmake ninja-build git binutils-devel clang fedora-clang-default-cc rpmbuild ccache
+RUN dnf -y install jq cmake ninja-build git binutils-devel clang rpmbuild ccache
 
 WORKDIR /root
 

--- a/scripts/git-bisect-script.sh
+++ b/scripts/git-bisect-script.sh
@@ -4,4 +4,4 @@ srpm_name=$1
 
 ninja -C build install-clang install-clang-resource-headers install-LLVMgold install-llvm-ar install-llvm-ranlib
 
-rpmbuild -rb $srpm_name
+rpmbuild -D '%toolchain clang' -rb $srpm_name


### PR DESCRIPTION
We can select the clang toolchain on the rpmbuild command line so we don't need this package.