### PR TITLE
Use centos-stream build roots for PGO

### DIFF
--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -198,7 +198,7 @@ def build_config_map() -> dict[str, Config]:
             maintainer_handle="kwk",
             copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
-            chroot_pattern="^fedora-rawhide-(x86_64|aarch64|ppc64le)|rhel-9-x86_64$",
+            chroot_pattern="^fedora-rawhide-(x86_64|aarch64|ppc64le)|centos-stream-9-x86_64|centos-stream-10-x86_64$",
             additional_copr_buildtime_repos=[
                 "copr://@fedora-llvm-team/llvm-test-suite/"
             ],


### PR DESCRIPTION
As a follow up for #1294 this drops the rhel-9 build root and adds centos-stream-9/10.