### PR TITLE
Provide secret GITHUB_TOKEN in workflow

### DIFF
--- a/.github/workflows/start-performance-comparison.yml
+++ b/.github/workflows/start-performance-comparison.yml
@@ -16,11 +16,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-python
       - name: "start-performance-comparison"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           today=$(date +%Y%m%d)
           yesterday=$(date -d "${today} -1 day" +%Y%m%d)
 
-          python3 ./snapshot_manager/main.py start-perf-comparison \
+          python3 ./snapshot_manager/main.py run-perf-comparison \
             --strategy-a pgo \
             --strategy-b big-merge \
             --yyyymmdd "$yesterday"

--- a/.github/workflows/update-diagrams.yml
+++ b/.github/workflows/update-diagrams.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           get_stats: ${{ github.event_name == 'schedule' && true || github.event.inputs.get_stats }}
           create_diagrams: ${{ github.event_name == 'schedule' && true || github.event.inputs.create_diagrams }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           today=$(date +%Y%m%d)
           yesterday=$(date -d "${today} -1 day" +%Y%m%d)


### PR DESCRIPTION
This should fix the following error introduced with #1305:

```
[17/Apr/2025 18:30:27] ERROR [main.py:121 main] Could not retrieve github token from environment variable with name 'GITHUB_TOKEN'
```

And change the command name from `start-perf-comparison` to
`run-perf-comparison`.