### PR TITLE
Use 'success' property correctly

### DIFF
--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -521,12 +521,12 @@ def run_performance_comparison(
         successful_a = [
             state.package_name
             for state in states_a
-            if state.chroot == chroot and state.copr_build_state.success
+            if state.chroot == chroot and state.success
         ]
         successful_b = [
             state.package_name
             for state in states_b
-            if state.chroot == chroot and state.copr_build_state.success
+            if state.chroot == chroot and state.success
         ]
         if (len(successful_a) == 0 or len(successful_b) == 0) or (
             set(successful_a) != set(successful_b)


### PR DESCRIPTION
This should fix this error:

```
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/snapshot_manager/snapshot_manager.py", line 524, in run_performance_comparison
    if state.chroot == chroot and state.copr_build_state.success
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'success'
```