### PR TITLE
Add testing-farm tokens to performance workflow

### DIFF
--- a/.github/workflows/start-performance-comparison.yml
+++ b/.github/workflows/start-performance-comparison.yml
@@ -18,6 +18,8 @@ jobs:
       - name: "start-performance-comparison"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TESTING_FARM_API_TOKEN_PUBLIC_RANCH: ${{ secrets.TESTING_FARM_API_TOKEN_PUBLIC_RANCH }}
+          TESTING_FARM_API_TOKEN_REDHAT_RANCH: ${{ secrets.TESTING_FARM_API_TOKEN_REDHAT_RANCH }}
         run: |
           today=$(date +%Y%m%d)
           yesterday=$(date -d "${today} -1 day" +%Y%m%d)


### PR DESCRIPTION
Before the workflow was missing these tokens which resulted in this error:

> SystemError: failed to run 'testing-farm request': testing-farm         request         --compose Fedora-Rawhide         --git-url https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git         --arch x86_64         --plan /tests/compare-comile-time         --context distro=fedora-rawhide         --context arch=x86_64         --context snapshot=20250502         --environment YYYYMMDD=20250502         --environment CONFIG_A=pgo         --environment CONFIG_B=big-merge         --environment CONFIG_A_COPR_PROJECT=llvm-snapshots-pgo-20250502         --environment CONFIG_B_COPR_PROJECT=llvm-snapshots-big-merge-20250502         --environment COPR_CHROOT=fedora-rawhide-x86_64
        --no-wait
        
> 
> stdout: 📦 repository https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git ref main test-type fmf
> 💻 Fedora-Rawhide on x86_64 
> ⛔ API token is invalid. See https://docs.testing-farm.io/general/0.1/onboarding.html for more information.