### PR TITLE
Avoid AttributeError: 'str' object has no attribute 'to_icon'

### DIFF
--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -535,7 +535,7 @@ def markdown_build_status_matrix(
         if state is not None:
             if state.copr_build_state is not None:
                 cols.append(
-                    f"[{state.copr_build_state.to_icon()}]({state.build_page_url})"
+                    f"[{CoprBuildStatus(state.copr_build_state).to_icon()}]({state.build_page_url})"
                 )
         else:
             cols.append(init_state)


### PR DESCRIPTION
This should fix this error when running the check-snapshots workflow:

```
 [03/May/2025 19:19:08] INFO [snapshot_manager.py:182 check_todays_builds] Add a build matrix
Traceback (most recent call last):
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/main.py", line 404, in <module>
    main()
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/main.py", line 79, in main
    SnapshotManager(config=cfg).check_todays_builds()
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/snapshot_manager/snapshot_manager.py", line 183, in check_todays_builds
    build_status_matrix = build_status.markdown_build_status_matrix(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/snapshot_manager/build_status.py", line 538, in markdown_build_status_matrix
    f"[{state.copr_build_state.to_icon()}]({state.build_page_url})"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'to_icon'
```