### PR TITLE
Add req id to perf request

### DIFF
--- a/snapshot_manager/testing_farm/request.py
+++ b/snapshot_manager/testing_farm/request.py
@@ -351,6 +351,7 @@ def make_compare_compile_time_request(
     exit_code, stdout, stderr = util.run_cmd(cmd, timeout_secs=None)
     if exit_code == 0:
         return Request(
+            request_id=tfutil.parse_output_for_request_id(stdout),
             test_plan_name=test_plan_name,
             chroot=chroot,
         )


### PR DESCRIPTION
The output of the testing-farm request ID in (#1351) revealed, that the request ID wasn't properly set for performance requests:

```
[03/May/2025 20:19:05] INFO [tfutil.py:67 adjust_token_env] Adjusting TESTING_FARM_API_TOKEN for ranch: public
[03/May/2025 20:19:06] INFO [snapshot_manager.py:543 run_performance_comparison] testing-farm request ID for fedora-rawhide-x86_64: None
```

Notice the `None` above. Analogue to snapshot gating requests this adds the ID correctly.