### PR TITLE
Typo in test-plan: compare-comile-time -> compare-compile-time

### DIFF
--- a/snapshot_manager/testing_farm/request.py
+++ b/snapshot_manager/testing_farm/request.py
@@ -324,7 +324,7 @@ def make_compare_compile_time_request(
     Returns:
         Request: testing-farm request object
     """
-    test_plan_name = "compare-comile-time"
+    test_plan_name = "compare-compile-time"
 
     logging.info(f"Kicking off new {test_plan_name} test for chroot {chroot}.")
 


### PR DESCRIPTION
This should fix the testing-farm error: `Did not find any plans.`