### PR TITLE
typo: CONFIG_A_COPR_PROJECT -> CONFIG_A_PROJECT_NAME

### DIFF
--- a/snapshot_manager/testing_farm/request.py
+++ b/snapshot_manager/testing_farm/request.py
@@ -342,8 +342,8 @@ def make_compare_compile_time_request(
         --environment YYYYMMDD={config_a.yyyymmdd} \
         --environment CONFIG_A={config_a.build_strategy} \
         --environment CONFIG_B={config_b.build_strategy} \
-        --environment CONFIG_A_COPR_PROJECT={config_a.copr_projectname} \
-        --environment CONFIG_B_COPR_PROJECT={config_b.copr_projectname} \
+        --environment CONFIG_A_PROJECT_NAME={config_a.copr_projectname} \
+        --environment CONFIG_B_PROJECT_NAME={config_b.copr_projectname} \
         --environment COPR_CHROOT={chroot}
         --no-wait
         """


### PR DESCRIPTION
The `compare-compile-time.fmf` file expects [`CONFIG_A_PROJECT_NAME`](https://github.com/fedora-llvm-team/llvm-snapshots/blob/9dee582a7bf8e278724089ad1379c484247ca8bc/tests/compare-compile-time.fmf#L99-L103) as an environment variable.

In contrast the testing-farm request passed [`CONFIG_A_COPR_PROJECT`](https://github.com/fedora-llvm-team/llvm-snapshots/blob/9dee582a7bf8e278724089ad1379c484247ca8bc/snapshot_manager/testing_farm/request.py#L345-L346).

This resulted in an empty copr project and so llvm was installed from the system repos.

Fixes #1366