### PR TITLE
Assign perf comparison issue to contender only

### DIFF
--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -562,7 +562,7 @@ This issue was created by [this action run]({os.getenv(key="ACTION_RUN_URL", def
     repo = github_client.get_repo(github_repo)
     issue = repo.create_issue(
         title=f"Performance comparison: {conf_a.build_strategy} vs. {conf_b.build_strategy} - {conf_a.yyyymmdd}",
-        assignees=[conf_a.maintainer_handle, conf_b.maintainer_handle],
+        assignees=[conf_a.maintainer_handle],
         labels=[
             f"strategy/{conf_a.build_strategy}",
             f"strategy/{conf_b.build_strategy}",

--- a/snapshot_manager/tests/snapshot_manager_test.py
+++ b/snapshot_manager/tests/snapshot_manager_test.py
@@ -216,7 +216,7 @@ def test_run_performance_comparison__full(
         kwargs["title"]
         == "Performance comparison: strategy A vs. strategy B - 20250402"
     )
-    assert kwargs["assignees"] == ["maintainerA", "maintainerB"]
+    assert kwargs["assignees"] == ["maintainerA"]
     assert kwargs["labels"] == [
         "strategy/strategy A",
         "strategy/strategy B",


### PR DESCRIPTION
Before, both maintainers have been assigned to a performance-comparison issue. But it should be enough to only assign it to the contending build strategy. So in case of a "pgo vs. big-merge" comparison, only the pgo-maintainer should be assigned to the performance-comparison issue.