### PR TITLE
Handle missing file in performance comparison request

### DIFF
--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -136,6 +136,7 @@ def read_url_response_into_file(url: str, **kw_args: Any) -> pathlib.Path:
     """
     logging.info(f"Getting URL {url}")
     response = requests.get(url)
+    response.raise_for_status()
     prefix: str | None = None
     if "prefix" in kw_args:
         prefix = kw_args.get("prefix", None)


### PR DESCRIPTION
This is especially useful when a performance comparison testing farm request failed. Then the constructed file (results.csv) won't be available.

In fact, this is the only place when we ignore the exception that is raised by `response.raise_for_status()`.

See #1378