### PR TITLE
Fixup for Workaround missing --json in "dnf repoinfo"

### DIFF
--- a/scripts/perf/lib.sh
+++ b/scripts/perf/lib.sh
@@ -107,7 +107,7 @@ function build_test_suite() {
     # Install and enable the repository that provides the LLVM Toolchain
     if [[ -n "${COPR_PROJECT}" ]]; then
         dnf copr enable -y ${COPR_OWNER}/${COPR_PROJECT} ${CHROOT}
-        local repo_file=$(dnf repoinfo '*${COPR_PROJECT}*' 2>/dev/null | grep -ioP 'Repo-filename\s*:\s*\K.*' | head -n1)
+        local repo_file=$(dnf repoinfo '*${COPR_PROJECT}*' 2>/dev/null | grep -ioP '(Repo-filename|Config file)\s*:\s*\K.*' | head -n1)
         distname=$(rpm --eval "%{?fedora:fedora}%{?rhel:rhel}")
         sed -i "s/\$distname/$distname/g" $repo_file
 


### PR DESCRIPTION
The original fix in #1377 was meant to fix centos-stream but it actually broke recent fedora versions where the config file is not listed under `Repo-filename` but under `Config file`. ...Sigh...

See PR: #1377