### PR TITLE
rebuilder: Start using rawhide chroots

### DIFF
--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -292,11 +292,11 @@ def build_pkg(
     project_name: str,
     copr_client: copr.v3.Client,
     pkg: str,
-    koji_server: str="https://koji.fedoraproject.org/kojihub",
-    default_commitish: str="rawhide",
-    build_tag: str="f43",
-    distgit: str="fedora",
-    chroots:list[str]= None,
+    koji_server: str = "https://koji.fedoraproject.org/kojihub",
+    default_commitish: str = "rawhide",
+    build_tag: str = "f43",
+    distgit: str = "fedora",
+    chroots:list[str] = None,
 ) -> None:
 
     buildopts = {"background": True, "chroots": chroots}

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -292,11 +292,11 @@ def build_pkg(
     project_name: str,
     copr_client: copr.v3.Client,
     pkg: str,
-    koji_server="https://koji.fedoraproject.org/kojihub": str,
-    default_commitish="rawhide": str,
-    build_tag="f43": str,
-    distgit="fedora": str,
-    chroots=None: list[str],
+    koji_server: str="https://koji.fedoraproject.org/kojihub",
+    default_commitish: str="rawhide",
+    build_tag: str="f43",
+    distgit: str="fedora",
+    chroots:list[str]= None,
 ) -> None:
 
     buildopts = {"background": True, "chroots": chroots}

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -5,7 +5,7 @@ import logging
 import re
 import sys
 import unittest
-from typing import Any
+from typing import Any, Optional
 
 import copr.v3
 import dnf

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -292,31 +292,33 @@ def build_pkg(
     project_name: str,
     copr_client: copr.v3.Client,
     pkg,
-    koji_server = "https://koji.fedoraproject.org/kojihub",
-    default_commitish = 'rawhide',
-    build_tag = 'f43',
-    distgit = 'fedora',
-    chroots = None
+    koji_server="https://koji.fedoraproject.org/kojihub",
+    default_commitish="rawhide",
+    build_tag="f43",
+    distgit="fedora",
+    chroots=None
 ):
 
-    buildopts = {
-        "background": True,
-        "chroots": chroots
-    }
+    buildopts = {"background": True, "chroots": chroots}
 
     koji_session = koji.ClientSession(koji_server)
     try:
         build = koji_session.getLatestBuilds(tag=build_tag, package=pkg)[0]
         build_info = koji_session.getBuild(build["build_id"])
         commitish = build_info["source"].split("#")[1]
-    except:
+    except:  # noqa: E722
         logging.warn(
             "Could not determine git commit for latest build of {p}.  Defaulting to {default_commitish}."
         )
         commitish = default_commitish
 
     copr_client.build_proxy.create_from_distgit(
-        project_owner, project_name, pkg, commitish, buildopts=buildopts, distgit=distgit
+        project_owner,
+        project_name,
+        pkg, 
+        commitish,
+        buildopts=buildopts,
+        distgit=distgit
     )
 
 
@@ -326,7 +328,7 @@ def start_rebuild(
     copr_client: copr.v3.Client,
     pkgs: set[str],
     snapshot_project_name: str,
-    chroots : list[str]
+    chroots: list[str]
 ) -> None:
     print("START", pkgs, "END")
     # Update the rebuild project to use the latest snapshot
@@ -341,7 +343,7 @@ def start_rebuild(
 
     logging.info("Rebuilding", len(pkgs), "packages")
     for p in pkgs:
-        build_pkg(project_owner, project_name, copr_client, p, chroots = chroots)
+        build_pkg(project_owner, project_name, copr_client, p, chroots=chroots)
 
 
 def select_snapshot_project(
@@ -473,7 +475,12 @@ def main() -> None:
         snapshot_project = select_snapshot_project(copr_client, target_chroots)
         if snapshot_project is not None:
             start_rebuild(
-                project_owner, project_name, copr_client, pkgs, snapshot_project, target_chroots
+                project_owner,
+                project_name,
+                copr_client,
+                pkgs,
+                snapshot_project,
+                target_chroots
             )
     elif args.command == "get-regressions":
         start_time = datetime.datetime.fromisoformat(args.start_date)

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -296,7 +296,7 @@ def build_pkg(
     default_commitish: str = "rawhide",
     build_tag: str = "f43",
     distgit: str = "fedora",
-    chroots:list[str] = None,
+    chroots: list[str] = None,
 ) -> None:
 
     buildopts = {"background": True, "chroots": chroots}

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -5,7 +5,7 @@ import logging
 import re
 import sys
 import unittest
-from typing import Any, Optional
+from typing import Any
 
 import copr.v3
 import dnf
@@ -296,7 +296,7 @@ def build_pkg(
     default_commitish: str = "rawhide",
     build_tag: str = "f43",
     distgit: str = "fedora",
-    chroots: Optional[list[str]] = None,
+    chroots: list[str] | None = None,
 ) -> None:
 
     buildopts = {"background": True, "chroots": chroots}

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -315,7 +315,7 @@ def build_pkg(
     copr_client.build_proxy.create_from_distgit(
         project_owner,
         project_name,
-        pkg, 
+        pkg,
         commitish,
         buildopts=buildopts,
         distgit=distgit

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -296,7 +296,7 @@ def build_pkg(
     default_commitish="rawhide",
     build_tag="f43",
     distgit="fedora",
-    chroots=None
+    chroots=None,
 ):
 
     buildopts = {"background": True, "chroots": chroots}
@@ -318,7 +318,7 @@ def build_pkg(
         pkg,
         commitish,
         buildopts=buildopts,
-        distgit=distgit
+        distgit=distgit,
     )
 
 
@@ -328,7 +328,7 @@ def start_rebuild(
     copr_client: copr.v3.Client,
     pkgs: set[str],
     snapshot_project_name: str,
-    chroots: list[str]
+    chroots: list[str],
 ) -> None:
     print("START", pkgs, "END")
     # Update the rebuild project to use the latest snapshot
@@ -480,7 +480,7 @@ def main() -> None:
                 copr_client,
                 pkgs,
                 snapshot_project,
-                target_chroots
+                target_chroots,
             )
     elif args.command == "get-regressions":
         start_time = datetime.datetime.fromisoformat(args.start_date)

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -296,7 +296,7 @@ def build_pkg(
     default_commitish: str = "rawhide",
     build_tag: str = "f43",
     distgit: str = "fedora",
-    chroots: list[str] = None,
+    chroots: Optional[list[str]] = None,
 ) -> None:
 
     buildopts = {"background": True, "chroots": chroots}

--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -291,13 +291,13 @@ def build_pkg(
     project_owner: str,
     project_name: str,
     copr_client: copr.v3.Client,
-    pkg,
-    koji_server="https://koji.fedoraproject.org/kojihub",
-    default_commitish="rawhide",
-    build_tag="f43",
-    distgit="fedora",
-    chroots=None,
-):
+    pkg: str,
+    koji_server="https://koji.fedoraproject.org/kojihub": str,
+    default_commitish="rawhide": str,
+    build_tag="f43": str,
+    distgit="fedora": str,
+    chroots=None: list[str],
+) -> None:
 
     buildopts = {"background": True, "chroots": chroots}
 


### PR DESCRIPTION
rawhide is the only Fedora release that we have s390x builds for, so we need to start using this for doing the rebuilds.

Also factor out the code for building a package, so we can reuse it in future changes to the script.