### PR TITLE
Future proof snapshot detection for snapshots

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -38,10 +38,10 @@ prepare:
       # Use a newer llvm-test-suite version from copr.
       - dnf copr enable -y @fedora-llvm-team/llvm-test-suite $COPR_CHROOT
 
-  - name: "Check that snapshot (~pre) version of LLVM is installed"
+  - name: "Check that snapshot version of LLVM is installed"
     how: shell
     order: 99
-    script: rpm -q --qf "%{version}" llvm-libs | grep '~pre'
+    script: rpm -q --qf "%{nvr}" llvm-libs | grep -P '~pre|pre\.'
 adjust:
   - discover+:
       - name: redhat-rpm-config-tests


### PR DESCRIPTION
When using `%autorelease` and [`autorelease_args`](https://fedora-infra.github.io/rpmautospec-docs/autorelease.html#example-the-snapshot-and-extraver-case) we'll move the `pre` part from the version-part to the release-part of the NVR. This change allows it to appear in both places of the NVR in order to work now and in the future.

Here's an example of the SRPM name when using `%autorelease`:

```
llvm-21.0.0-1.pre.20250506g8b9ae65d51a14c.fc41.src.rpm
           ^ release part starts here
```

Here's the SRPM name without using `%autorelease` (what we currently have):

```
llvm-21.0.0~pre20250506.g8b9ae65d51a14c-2.fc41.src.rpm
                                       ^ release part starts here
```

The difference is subtle but without this PR we won't be able to identify snapshots properly when moving to `%autorelease`.



