### PR TITLE
remove --hierachic=never parameter from lscpu

### DIFF
--- a/scripts/perf/lib.sh
+++ b/scripts/perf/lib.sh
@@ -238,7 +238,7 @@ function _csv() {
 # Sets cpu_header_line and cpu_line variables for usage in CSV
 function _gather_cpu_info() {
     local lscpu_out=$(mktemp)
-    lscpu --hierarchic=never --json --bytes > $lscpu_out
+    lscpu --json --bytes > $lscpu_out
 
     cpu_header_line=""
     cpu_line=""


### PR DESCRIPTION
when redirecting (which we do) `lscpu` won't use subsections anyways.

Here's the excerpt from the `lscpu` manual:

```
       --hierarchic[=when]
           Use subsections in summary output. For backward compatibility, the default is to use subsections only when output on a terminal and flattened output on a non-terminal. The
           optional argument when can be never, always or auto. If the when argument is omitted, it defaults to "always".
```

Fixes #1395