### PR TITLE
Misc fixes

### DIFF
--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -122,10 +122,11 @@ class BuildState:
 
     def render_as_markdown(self) -> str:
         """Return an HTML string representation of this Build State to be used in a github issue"""
-        quoted_build_log_link = urllib.parse.quote(self.build_log_url)
-        link = f'<a href="{self.build_log_url}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">Teach AI</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
-        if self.url_build_log is None:
+        if self.url_build_log is None or self.url_build_log.strip() == "":
             link = f'<a href="{self.build_page_url}">build page</a>'
+        else:
+            quoted_build_log_link = urllib.parse.quote(self.url_build_log)
+            link = f'<a href="{self.url_build_log}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">Teach AI</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
 
         return f"""
 <details>
@@ -192,11 +193,6 @@ class BuildState:
         'https://copr.fedorainfracloud.org/coprs/build/123'
         """
         return f"https://copr.fedorainfracloud.org/coprs/build/{self.build_id}"
-
-    @property
-    def build_log_url(self) -> str:
-        """Returns the URL to to the build log page for this build state"""
-        return self.url_build_log
 
     def augment_with_error(self) -> "BuildState":
         """Inspects the build status and if it is an error it will get and scan the logs"""

--- a/snapshot_manager/testing_farm/tfutil.py
+++ b/snapshot_manager/testing_farm/tfutil.py
@@ -212,8 +212,16 @@ def get_xunit_file_from_request_file(
     request_file: pathlib.Path, request_id: uuid.UUID
 ) -> pathlib.Path | None:
     result_json = json.loads(request_file.read_text())
+    if result_json is None:
+        logging.info(f"Loading request file returned None: {request_file}")
+        return None
     if "result" not in result_json:
         raise KeyError("failed to find 'result' key in JSON result response")
+    if result_json["result"] is None:
+        logging.info(
+            f"'result' key in JSON request file (state={result_json["state"]}) is None: {request_file}"
+        )
+        return None
     if "xunit_url" not in result_json["result"]:
         raise KeyError("failed to find 'xunit_url' key in result dict response")
     xunit_url = result_json["result"]["xunit_url"]

--- a/snapshot_manager/tests/build_status_test.py
+++ b/snapshot_manager/tests/build_status_test.py
@@ -72,7 +72,7 @@ class TestErrorCauseAndBuildStatus(base_test.TestBase):
 </details>"""
         self.assertEqual(expected_result, matrix)
 
-    def test_render_as_markdown(self) -> None:
+    def test_render_as_markdown__normal(self) -> None:
         """Test HTML string representation of a BuildState"""
         state = build_status.BuildState(
             err_cause=build_status.ErrorCause.ISSUE_NETWORK,
@@ -95,6 +95,31 @@ This is the context for the error
 </details>
 """
         self.assertEqual(expected, state.render_as_markdown())
+
+
+def test_render_as_markdown__no_build_log_url() -> None:
+    """Test HTML string representation of a BuildState without a build log URL"""
+    state = build_status.BuildState(
+        err_cause=build_status.ErrorCause.ISSUE_NETWORK,
+        package_name="foo",
+        chroot="fedora-40-x86_64",
+        url_build_log="",
+        url_build="https://example.com/url_build",
+        build_id=1234,
+        err_ctx="This is the context for the error",
+        copr_ownername="foo",
+        copr_projectname="bar",
+    )
+
+    expected = f"""
+<details>
+<summary>
+<code>foo</code> on <code>fedora-40-x86_64</code> (see <a href="{state.build_page_url}">build page</a>)
+</summary>
+This is the context for the error
+</details>
+"""
+    assert expected == state.render_as_markdown()
 
 
 class TestErrorList(base_test.TestBase):


### PR DESCRIPTION
# Gracefully handle ongoing testing-farm requests

Sometimes a request file's `result` property is empty because a request
was still running. This handles this case gracefully without crashing.


# Fix: TypeError("quote_from_bytes() expected bytes")

Check `BuildState.url_build_log` before using it and add a test.
Remove `BuildState.build_log_url` property which just returned
`BuildState.url_build_log`.

This fixes the following error which was last seen in [this run](https://github.com/fedora-llvm-team/llvm-snapshots/actions/runs/15135140748/job/42545138528#step:6:89):

```
 Traceback (most recent call last):
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/main.py", line 404, in <module>
    main()
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/main.py", line 79, in main
    SnapshotManager(config=cfg).check_todays_builds()
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/snapshot_manager/snapshot_manager.py", line 243, in check_todays_builds
    {build_status.render_as_markdown(errors_for_this_chroot)}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/snapshot_manager/build_status.py", line 509, in render_as_markdown
    html += f"<li>{state.render_as_markdown()}</li>"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/llvm-snapshots/llvm-snapshots/snapshot_manager/snapshot_manager/build_status.py", line 125, in render_as_markdown
    quoted_build_log_link = urllib.parse.quote(self.build_log_url)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/urllib/parse.py", line 927, in quote
    return quote_from_bytes(string, safe)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/urllib/parse.py", line 957, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```
