### PR TITLE
Fix snapshots disable pgo builds

### DIFF
--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -185,6 +185,9 @@ def build_config_map() -> dict[str, Config]:
             copr_project_tpl="llvm-snapshots-big-merge-YYYYMMDD",
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD/monitor/",
             chroot_pattern="^(fedora-(rawhide|[0-9]+)|centos-stream-[10,9]|rhel-8)",
+            additional_copr_buildtime_repos=[
+                "copr://@fedora-llvm-team/llvm-test-suite/"
+            ],
         ),
         Config(
             build_strategy="pgo",

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -189,19 +189,6 @@ def build_config_map() -> dict[str, Config]:
                 "copr://@fedora-llvm-team/llvm-test-suite/"
             ],
         ),
-        Config(
-            build_strategy="pgo",
-            copr_target_project="@fedora-llvm-team/llvm-snapshots-pgo",
-            package_clone_url="https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
-            package_clone_ref="pgo",
-            maintainer_handle="kwk",
-            copr_project_tpl="llvm-snapshots-pgo-YYYYMMDD",
-            copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-pgo-YYYYMMDD/monitor/",
-            chroot_pattern="^fedora-rawhide-(x86_64|aarch64|ppc64le)|centos-stream-9-x86_64|centos-stream-10-x86_64$",
-            additional_copr_buildtime_repos=[
-                "copr://@fedora-llvm-team/llvm-test-suite/"
-            ],
-        ),
     ]
 
     return {config.build_strategy: config for config in configs}


### PR DESCRIPTION
1. This ensures we fix the regular snapshot builds on RHEL/Centos because they now require access to `llvm-test-suite` which we provide through copr, just like we did for the pgo build strategy before.
1. This ensures we no longer build the pgo build strategy separately, now that [PGO in rawhide](https://src.fedoraproject.org/rpms/llvm/pull-request/428) has landed.

NOTE: After this lands I'm going to rebuild today's snapshots and run the performance tests for one last time (before we do the same with BOLT). Then I'm going to disable the performance tests in a separate PR.