### PR TITLE
Fix errors caused by very long Github comments

### DIFF
--- a/snapshot_manager/snapshot_manager/build_status.py
+++ b/snapshot_manager/snapshot_manager/build_status.py
@@ -120,7 +120,7 @@ class BuildState:
     copr_ownername: str = ""
     copr_projectname: str = ""
 
-    def render_as_markdown(self) -> str:
+    def render_as_markdown(self, shortened: bool = False) -> str:
         """Return an HTML string representation of this Build State to be used in a github issue"""
         if self.url_build_log is None or self.url_build_log.strip() == "":
             link = f'<a href="{self.build_page_url}">build page</a>'
@@ -128,12 +128,16 @@ class BuildState:
             quoted_build_log_link = urllib.parse.quote(self.url_build_log)
             link = f'<a href="{self.url_build_log}">build log</a>, <a href="https://logdetective.com/contribute/copr/{self.build_id:08}/{self.chroot}">Teach AI</a>, <a href="https://log-detective.com/explain?url={quoted_build_log_link}">Ask AI</a>'
 
+        if shortened:
+            details = "The log of errors is too long for Github. See the details in the build log."
+        else:
+            details = self.err_ctx
         return f"""
 <details>
 <summary>
 <code>{self.package_name}</code> on <code>{self.chroot}</code> (see {link})
 </summary>
-{self.err_ctx}
+{details}
 </details>
 """
 
@@ -485,7 +489,7 @@ def list_only_errors(states: BuildStateList) -> BuildStateList:
     ]
 
 
-def render_as_markdown(states: BuildStateList) -> str:
+def render_as_markdown(states: BuildStateList, shortened: bool = False) -> str:
     """Sorts the build state list and renders it as HTML
 
     Args:
@@ -502,7 +506,7 @@ def render_as_markdown(states: BuildStateList) -> str:
             if last_cause is not None:
                 html += "</ol></li>"
             html += f"<li><b>{state.err_cause}</b><ol>"
-        html += f"<li>{state.render_as_markdown()}</li>"
+        html += f"<li>{state.render_as_markdown(shortened=shortened)}</li>"
         last_cause = state.err_cause
     if html != "":
         html += "</ol></li></ul>"

--- a/snapshot_manager/snapshot_manager/snapshot_manager.py
+++ b/snapshot_manager/snapshot_manager/snapshot_manager.py
@@ -235,13 +235,19 @@ class SnapshotManager:
             ]
             marker = f"<!--ERRORS_FOR_CHROOT/{chroot}-->"
             if errors_for_this_chroot is not None and len(errors_for_this_chroot) > 0:
+                # Github limits the maximum length of a comment at 65536 characters.
+                max_length = 65536
+                body = f"""{marker}
+<h3>Errors found in Copr builds on <code>{chroot}</code></h3>
+{build_status.render_as_markdown(errors_for_this_chroot)}"""
+                if len(body) > max_length:
+                    body = f"""{marker}
+<h3>Errors found in Copr builds on <code>{chroot}</code></h3>
+{build_status.render_as_markdown(errors_for_this_chroot, shortened=True)}"""
                 comment = self.github.create_or_update_comment(
                     issue=issue,
                     marker=marker,
-                    comment_body=f"""{marker}
-<h3>Errors found in Copr builds on <code>{chroot}</code></h3>
-{build_status.render_as_markdown(errors_for_this_chroot)}
-""",
+                    comment_body=body,
                 )
                 self.github.unminimize_comment(comment)
                 build_status_matrix = build_status_matrix.replace(


### PR DESCRIPTION
Avoid printing comments that are longer than Github's 65536 limit. This limit is rarely passed, but when it is, it causes an exception that abort the execution of the Github Action.
In the rare cases this happens, it's better to have just a link to the build log and a successful execution than aborting everything.