### PR TITLE
[diagrams] No longer fetch PGO build-stats or perf-results

### DIFF
--- a/.github/workflows/update-diagrams.yml
+++ b/.github/workflows/update-diagrams.yml
@@ -66,19 +66,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           today=$(date +%Y%m%d)
-          yesterday=$(date -d "${today} -1 day" +%Y%m%d)
+          #yesterday=$(date -d "${today} -1 day" +%Y%m%d)
 
           if ${{ env.get_stats }}; then
             main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-big-merge-${today}" | tee -a gh-pages/build-stats-big-merge.csv
-            main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-pgo-${today}" | tee -a gh-pages/build-stats-pgo.csv
-            python3 ./main/snapshot_manager/main.py \
-              --github-repo "${GITHUB_REPOSITORY}" \
-              collect-perf-results \
-              --strategy-a pgo \
-              --strategy-b big-merge \
-              --csv-file-in gh-pages/perf-results.csv \
-              --csv-file-out gh-pages/perf-results.csv \
-              --yyyymmdd "${yesterday}"
+            # main/scripts/get-build-stats.py --copr-projectname "llvm-snapshots-pgo-${today}" | tee -a gh-pages/build-stats-pgo.csv
+            # python3 ./main/snapshot_manager/main.py \
+            #   --github-repo "${GITHUB_REPOSITORY}" \
+            #   collect-perf-results \
+            #   --strategy-a pgo \
+            #   --strategy-b big-merge \
+            #   --csv-file-in gh-pages/perf-results.csv \
+            #   --csv-file-out gh-pages/perf-results.csv \
+            #   --yyyymmdd "${yesterday}"
             git -C gh-pages add build-stats-big-merge.csv build-stats-pgo.csv perf-results.csv
           fi
           if ${{ env.create_diagrams }}; then


### PR DESCRIPTION
PGO is now integrated and no longer lives in its own branch.

This should fix [this error](https://github.com/fedora-llvm-team/llvm-snapshots/actions/runs/15429760776/job/43425086882):

```
[03/Jun/2025 23:15:25] ERROR [main.py:128 main] 'pgo' and 'big-merge' need to be a named configuration but currently only these configurations exist: dict_keys(['big-merge'])
```

See #1475 for no longer building dedicated PGO builds
See #1476 for no longer scheduling performance tests

The code is commented out and not removed because we might wan to turn it back on in the future when comparing regular builds to builds that use BOLT.