### PR TITLE
When xuint URL is None, log summary and overall result.

### DIFF
--- a/snapshot_manager/testing_farm/tfutil.py
+++ b/snapshot_manager/testing_farm/tfutil.py
@@ -233,6 +233,12 @@ def get_xunit_file_from_request_file(
         )
         return None
 
+    if xunit_url is None:
+        logging.error(
+            f"Error: xunit URL is None. Overall: {result_json["overall"]} Summary: {result_json["summary"]}"
+        )
+        return None
+
     logging.info(f"Fetching xunit URL from URL: {xunit_url}")
 
     if not _IN_TEST_MODE:


### PR DESCRIPTION
Lately I've been seeing these errors:

```
[05/Aug/2025 22:34:42] INFO [util.py:137 read_url_response_into_file] Getting URL https://api.testing-farm.io/v0.1/requests/985cbe62-61dc-48c9-9428-0603509cf570
[05/Aug/2025 22:34:42] INFO [tfutil.py:236 get_xunit_file_from_request_file] Fetching xunit URL from URL: None
```

This is the relevant part of the [JSON](https://api.testing-farm.io/v0.1/requests/985cbe62-61dc-48c9-9428-0603509cf570). 

```json
  "result": {
    "summary": "Failed to discover tests, TMT metadata are absent or corrupted. Search for '[E] [test-schedule-tmt' on the artifacts page for details.",
    "overall": "error",
    "xunit_url": null
  },
```

With this change, we'll stop trying to fetch the `xuint_url` if it is `None` and instead log the error.