### PR TITLE
Handle timeout in run_cmd()

### DIFF
--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -113,10 +113,19 @@ def run_cmd(cmd: str, timeout_secs: int | None = 5) -> tuple[int, str, str]:
     'hello\\n'
     """
 
-    proc = subprocess.run(shlex.split(cmd), timeout=timeout_secs, capture_output=True)
-    stdout = proc.stdout.decode()
-    stderr = proc.stderr.decode()
-    exit_code = proc.returncode
+    try:
+        proc = subprocess.run(
+            shlex.split(cmd), timeout=timeout_secs, capture_output=True
+        )
+        stdout = proc.stdout.decode()
+        stderr = proc.stderr.decode()
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired as e:
+        exit_code = -1
+        stdout = e.stdout.decode() if e.stdout is not None else ""
+        stderr = e.stderr.decode() if e.stderr is not None else ""
+        stderr += f"\n\nCommand timed out after {e.timeout} seconds."
+
     if exit_code != 0:
         logging.debug(
             f"exit code: {proc.returncode} for cmd: {cmd}\n\nstdout={stdout}\n\nstderr={stderr}"


### PR DESCRIPTION
If run_cmd() times out, treat it as a failing command and append a timeout messaget stderr. Previously, it would throw an exception instead.

This handles an issue encountered in #1608, where very large logs make grep commands time out. We should handle this more gracefully.