### PR TITLE
Increase the priority of the copr repos when testing

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -10,21 +10,11 @@
 
 summary: LLVM Tests for snapshot gating
 prepare:
-  # Lower the priority of the testing-farm-tag-repository so that our copr repo is picked up.
-  # See: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
-  - name: Set testing-farm-tag-repository priority
-    how: shell
-    script: |
-      if dnf repolist | grep -q testing-farm-tag-repository; then
-        dnf install -y 'dnf5-command(config-manager)' || dnf install -y 'dnf-command(config-manager)'
-        dnf config-manager --save --setopt="testing-farm-tag-repository.priority=999" || \
-          dnf config-manager setopt "testing-farm-tag-repository.priority=999"
-      fi
-
   - name: Enable copr repo
     how: shell
     script:
       - dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)'
+      - dnf install -y 'dnf5-command(config-manager)' || dnf install -y 'dnf-command(config-manager)'
       - dnf -y copr enable @fedora-llvm-team/$COPR_PROJECT $COPR_CHROOT
       # dnf5's copr plugin has trouble resolving the runtime dependency repos,
       # and is not replacing the $distname special var. Hence we need to do that
@@ -37,6 +27,10 @@ prepare:
       - dnf -y install --best llvm-libs
       # Use a newer llvm-test-suite version from copr.
       - dnf copr enable -y @fedora-llvm-team/llvm-test-suite $COPR_CHROOT
+      # Increase the priority of the copr repositories in order to prefer packages from them.
+      # Testing Farm uses priority=9 by default.
+      # Source: https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_tag_repository
+      - dnf config-manager --save --setopt="copr:copr.fedorainfracloud.org:group_fedora-llvm-team:*.priority=8" || dnf config-manager setopt "copr:copr.fedorainfracloud.org:group_fedora-llvm-team:*.priority=8"
 
   - name: "Check that snapshot version of LLVM is installed"
     how: shell


### PR DESCRIPTION
Instead of decreasing the priority of the Testing Farm repositories,
increase the priority of our Copr repositories in order to guarantee
that packages from the daily snapshots are preferred.

This also fix an issue caused by Testing Farm repositories changing
names recently.

Fixes #395.