### PR TITLE
Remove non-rawhide support from get_tier2_pkgs()

### DIFF
--- a/scripts/rebuilder.py
+++ b/scripts/rebuilder.py
@@ -138,11 +138,9 @@ def get_tier1_pkgs(version: int) -> set[str]:
     return filter_unsupported_pkgs(filter_req_pkgs(base))
 
 
-def get_tier2_pkgs(version: str = "rawhide") -> set[str]:
-    """Returns all packages that BuildRequires clang for the given Fedora version
+def get_tier2_pkgs() -> set[str]:
+    """Returns all packages that BuildRequires clang for Fedora rawhide
 
-    Args:
-        version (str): A Fedora version string e.g. rawhide, 43, 42, etc.
     Returns:
         set[str]: A set of package names.
     Exmaple:
@@ -150,36 +148,18 @@ def get_tier2_pkgs(version: str = "rawhide") -> set[str]:
     >>> pkgs=get_tier2_pkgs()
     >>> len(pkgs) > 0
     True
-    >>> pkgs=get_tier2_pkgs(str(int(get_rawhide_tag()[1:])-1))
-    >>> len(pkgs) > 0
-    True
     """
     base = dnf.Base()
     conf = base.conf
+    version = "rawhide"
 
-    if version == "rawhide":
-        base.repos.add_new_repo(
-            f"{version}-source",
-            conf,
-            baseurl=[
-                f"https://download-ib01.fedoraproject.org/pub/fedora/linux/development/{version}/Everything/source/tree/"
-            ],
-        )
-    else:
-        base.repos.add_new_repo(
-            f"{version}-source",
-            conf,
-            baseurl=[
-                f"https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/{version}/Everything/source/tree/"
-            ],
-        )
-        base.repos.add_new_repo(
-            f"{version}-updates-source",
-            conf,
-            baseurl=[
-                f"https://download-ib01.fedoraproject.org/pub/fedora/linux/updates/{version}/Everything/source/tree/"
-            ],
-        )
+    base.repos.add_new_repo(
+        f"{version}-source",
+        conf,
+        baseurl=[
+            f"https://download-ib01.fedoraproject.org/pub/fedora/linux/development/{version}/Everything/source/tree/"
+        ],
+    )
 
     return filter_req_pkgs(base)
 


### PR DESCRIPTION
This is broken for branched releases (which should be treated similar to rawhide, not to released versions). I could fix this, but apparently this function is only actually called with rawhide, so I just dropped the dead code instead. Happy to go the other way around (and e.g. check if the URL 404s, or check something like https://fedorapeople.org/groups/qa/metadata/release.json for release status.)